### PR TITLE
Add colors to flash card performance and related cards

### DIFF
--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -338,6 +338,12 @@ ul {
     font-weight: bold;
 }
 
+/* TODO: font-size: larger, etc.? */
+.emphasized-but-not-that-emphasized {
+    font-size: 16px;
+    font-weight: bold;
+}
+
 .emphasized-target {
     font-size: 24px;
     font-weight: bold;
@@ -941,6 +947,8 @@ svg+.explore-stat-header {
     margin: 10px auto;
     text-align: center;
     width: 80%;
+    /* extra height for emphasized elements + padding */
+    line-height: 24px;
 }
 
 .card-detail p {
@@ -953,10 +961,28 @@ svg+.explore-stat-header {
 
 p.related-card {
     margin: 6px auto;
+    font-weight: 400;
 }
 
 .related-card-performance {
     font-size: 16px;
+}
+
+.bad-performance,
+.ok-performance,
+.good-performance {
+    color: black;
+    padding: 1px 2px;
+}
+
+.bad-performance {
+    background-color: #ff635f;
+}
+.ok-performance {
+    background-color:  #ffc300;
+}
+.good-performance {
+    background-color: var(--positive-button-color);
 }
 
 #delete-card-button {

--- a/public/index.html
+++ b/public/index.html
@@ -105,15 +105,16 @@
                         </ul>
                         <p id="delete-card-button" class="active-link">Delete this card</p>
                         <div id="past-performance-container" class="card-detail">
-                            <p id="card-new-message" style="display:none">This is a new card!</p>
+                            <p id="card-new-message" style="display:none">This is a <span class="emphasized">new</span> card!</p>
                             <div id="card-old-message" style="display: none;">
-                                <p>Previous attempts: <span id="card-percentage"></span>% correct.</p>
-                                <p>Right <span id="card-right-count"></span>; Wrong <span id="card-wrong-count"></span>.
+                                <p>Previous attempts: <span id="card-percentage" class="emphasized"></span> correct.</p>
+                                <p>Right <span id="card-right-count" class="emphasized-but-not-that-emphasized"></span>; Wrong <span id="card-wrong-count" class="emphasized-but-not-that-emphasized"></span>.
                                 </p>
+                                <p id="card-added-time-container">Card added: <span class="emphasized-but-not-that-emphasized" id="card-added-time"></span></p>
                             </div>
                         </div>
                         <div id="related-cards-container" class="card-detail" style="display:none">
-                            Other cards with <span id="related-card-query"></span>:
+                            Other cards with <span class="emphasized-target" id="related-card-query"></span>:
                             <div id="related-cards" class="related-cards"></div>
                         </div>
                     </div>
@@ -275,7 +276,8 @@
                 system, like Anki.
             </p>
             <h3>Where are the flashcards stored?</h3>
-            <p>All data for the site is stored in <a
+            <p>If you are signed in, the data is stored on our servers, and synced across any other device where you sign in.
+                If you are not signed in, all data for the site is stored in <a
                     href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage">localStorage</a>.
                 It
                 does not leave your browser, and clearing your browser data will clear it.

--- a/public/js/modules/study-mode.js
+++ b/public/js/modules/study-mode.js
@@ -15,6 +15,8 @@ const cardAnswerElement = document.getElementById('card-answer');
 const wrongButton = document.getElementById('wrong-button');
 const rightButton = document.getElementById('right-button');
 const deleteCardButton = document.getElementById('delete-card-button');
+const cardAddedTime = document.getElementById('card-added-time');
+const cardAddedTimeContainer = document.getElementById('card-added-time-container');
 
 const relatedCardsContainer = document.getElementById('related-cards-container');
 const relatedCardsElement = document.getElementById('related-cards');
@@ -120,13 +122,30 @@ let displayRelatedCards = function (anchor) {
         let item = document.createElement('p');
         item.className = 'related-card';
         item.innerText = related[i];
-        let relatedPerf = document.createElement('p');
-        relatedPerf.className = 'related-card-performance';
-        relatedPerf.innerText = `(right ${studyList[related[i]].rightCount || 0}, wrong ${studyList[related[i]].wrongCount || 0})`;
-        item.appendChild(relatedPerf);
+        let relatedPerfContainer = document.createElement('p');
+        relatedPerfContainer.classList.add('related-card-performance');
+        let relatedPerf = document.createElement('span');
+        relatedPerf.classList.add('emphasized');
+        const percentage = Math.round(100 * studyList[related[i]].rightCount / ((studyList[related[i]].rightCount + studyList[related[i]].wrongCount) || 1))
+        setPerformanceClass(percentage, relatedPerf);
+        relatedPerfContainer.appendChild(relatedPerf);
+        relatedPerfContainer.innerHTML += ' correct.';
+        item.appendChild(relatedPerfContainer);
         relatedCardsElement.appendChild(item);
     }
     relatedCardsContainer.removeAttribute('style');
+}
+
+function setPerformanceClass(correctPercentage, container) {
+    container.classList.remove('good-performance', 'ok-performance', 'bad-performance')
+    container.textContent = `${correctPercentage}%`;
+    if (correctPercentage >= 80) {
+        container.classList.add('good-performance');
+    } else if (correctPercentage < 80 && correctPercentage >= 60) {
+        container.classList.add('ok-performance');
+    } else {
+        container.classList.add('bad-performance')
+    }
 }
 
 let setupStudyMode = function () {
@@ -164,9 +183,22 @@ let setupStudyMode = function () {
     if (currentCard.wrongCount + currentCard.rightCount != 0) {
         cardOldMessageElement.removeAttribute('style');
         cardNewMessageElement.style.display = 'none';
-        cardPercentageElement.textContent = Math.round(100 * currentCard.rightCount / ((currentCard.rightCount + currentCard.wrongCount) || 1));
+        const correctPercentage = Math.round(100 * currentCard.rightCount / ((currentCard.rightCount + currentCard.wrongCount) || 1));
+        setPerformanceClass(correctPercentage, cardPercentageElement);
         cardRightCountElement.textContent = `${currentCard.rightCount || 0} time${currentCard.rightCount != 1 ? 's' : ''}`;
         cardWrongCountElement.textContent = `${currentCard.wrongCount || 0} time${currentCard.wrongCount != 1 ? 's' : ''}`;
+        if (currentCard.added) {
+            cardAddedTimeContainer.removeAttribute('style');
+            cardAddedTime.innerText = new Date(Number(currentCard.added)).toLocaleDateString('en-US',
+                {
+                    weekday: "long",
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric"
+                })
+        } else {
+            cardAddedTimeContainer.style.display = 'none';
+        }
     } else {
         cardNewMessageElement.removeAttribute('style');
         cardOldMessageElement.style.display = 'none';


### PR DESCRIPTION
This commit also tweaks the styles slightly to improve the look and feel of the study mode UI. Upcoming commits will enable word-level related cards and performance stats, in addition to the current character-level stats.