### PR TITLE
Combine header and search form

### DIFF
--- a/public/components/index.html
+++ b/public/components/index.html
@@ -100,7 +100,13 @@
         <div id="left-menu-button-container" class="left-menu-button-container">
             <i id="left-menu-button" class="menu-button"></i>
         </div>
-        <h1 id="main-header" class="main-header">HanziGraph</h1>
+        <img class="logo" src="/images/hanzigraph-192x192.png"/>
+        <h1 id="text-header" style="display:none">HanziGraph</h1>
+        <form id="search-form">
+            <input id="hanzi-box" aria-label="Pick a hanzi or word" placeholder="Pick a hanzi or word" type="search"
+                enterkeyhint="search" class="primary-input" autocapitalize="off" autocomplete="off" />
+            <ul id="search-suggestions-container" class="search-suggestions" style="display:none"></ul>
+        </form>
         <div id="right-menu-button-container" class="right-menu-button-container">
             <a href="https://github.com/mreichhoff/HanziGraph/blob/main/README.md">
                 <svg stroke="currentColor" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" fill="currentColor"
@@ -113,41 +119,33 @@
         </div>
     </header>
     <div id="main-app-container" class="primary-container">
-        <div id="controls" class="control-container">
-            <form id="search-form">
-                <input id="hanzi-box" aria-label="Choose any hanzi" placeholder="Choose any hanzi" type="search"
-                    enterkeyhint="search" class="primary-input" autocapitalize="off" autocomplete="off" />
-            </form>
+        <div id="text-container" class="primary-panel">
+            <div id="explore-container" class="section-container">
+                <p style="display:none" id="not-found-message">No data found 😞. Please try another.</p>
+                <div id="walkthrough" class="walkthrough">
+                    <p>To get started, click the diagram, or search for any character.</p>
+                    <p>The diagram shows the components of each character, the components of its components, and so
+                        on.</p>
+                    <p>
+                        The diagram is color-coded by tone. When a component has similar pronunciation with its
+                        parent, a label with pinyin (initial, final, or both) is shown. </p>
+                    <p>Pinyin rules can be found on
+                        <a class="active-link" href="https://pinyin.info/rules/initials_finals.html">pinyin.info</a>
+                    </p>
+                </div>
+                <div id="examples">
+                </div>
+            </div>
         </div>
-        <div id="data-container" class="output-container">
-            <div id="text-container" class="primary-panel">
-                <div id="explore-container" class="section-container">
-                    <p style="display:none" id="not-found-message">No data found 😞. Please try another.</p>
-                    <div id="walkthrough" class="walkthrough">
-                        <p>To get started, click the diagram, or search for any character.</p>
-                        <p>The diagram shows the components of each character, the components of its components, and so
-                            on.</p>
-                        <p>
-                            The diagram is color-coded by tone. When a component has similar pronunciation with its
-                            parent, a label with pinyin (initial, final, or both) is shown. </p>
-                        <p>Pinyin rules can be found on
-                            <a class="active-link" href="https://pinyin.info/rules/initials_finals.html">pinyin.info</a>
-                        </p>
-                    </div>
-                    <div id="examples">
-                    </div>
-                </div>
+        <div id="graph-container" class="primary-panel">
+            <div id="tone-legend" class="legend">
+                <span class="tone1">1st tone</span>
+                <span class="tone2">2nd tone</span>
+                <span class="tone3">3rd tone</span>
+                <span class="tone4">4th tone</span>
+                <span class="tone-neutral">Other</span>
             </div>
-            <div id="graph-container" class="primary-panel">
-                <div id="tone-legend" class="legend">
-                    <span class="tone1">1st tone</span>
-                    <span class="tone2">2nd tone</span>
-                    <span class="tone3">3rd tone</span>
-                    <span class="tone4">4th tone</span>
-                    <span class="tone-neutral">Other</span>
-                </div>
-                <div id="graph" class="graph"></div>
-            </div>
+            <div id="graph" class="graph"></div>
         </div>
     </div>
     <div id="menu-container" style="display:none">

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -137,6 +137,15 @@ ul {
     border: 2px solid black;
 }
 
+.header.has-suggestions {
+    height: auto;
+}
+
+.header .logo {
+    height: var(--primary-header-height);
+    width: var(--primary-header-height);
+}
+
 .control-container {
     max-width: 1000px;
     margin: 0 auto;
@@ -174,6 +183,7 @@ ul {
     width: 50%;
     display: flex;
     flex-direction: column;
+    margin: var(--primary-panel-margin);
 }
 
 .section-container {

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -143,17 +143,13 @@ ul {
     border: 3px solid black;
     cursor: pointer;
 }
+
 .header .logo.freq {
     background-color: var(--tone-1-color);
 }
 
 .header.has-suggestions {
     height: auto;
-}
-
-.header .logo {
-    height: var(--primary-header-height);
-    width: var(--primary-header-height);
 }
 
 .control-container {
@@ -178,10 +174,6 @@ ul {
     box-shadow: var(--primary-input-box-shadow);
 }
 
-#walkthrough-character-set {
-    font-weight: bold;
-}
-
 .primary-container {
     height: var(--primary-container-height);
     display: flex;
@@ -194,6 +186,10 @@ ul {
     display: flex;
     flex-direction: column;
     margin: var(--primary-panel-margin);
+}
+
+.walkthrough h1 {
+    text-align: center;
 }
 
 .section-container {
@@ -490,11 +486,6 @@ h2.word-header {
 
 .coverage-explanation+svg {
     margin-top: 6px;
-}
-
-.suggestions-explanation {
-    font-size: var(--instructions-font-size);
-    margin-top: 4px;
 }
 
 .context,
@@ -889,6 +880,7 @@ h2.word-header {
     text-align: center;
     list-style-type: none;
     overflow: hidden;
+    background-color: var(--background-color);
 }
 
 .search-suggestion {

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -1248,19 +1248,19 @@ main.auth-form {
     }
 
     #text-container {
-        height: 45%;
+        height: 50%;
     }
 
     /* TODO(refactor): why is this media query using graph-container but the main one uses graph? */
     #graph-container {
-        height: 55%;
+        height: 50%;
         border-top: var(--border);
     }
 
     /* should be unreachable other than when this media query is reached... */
     @keyframes expand-panel {
         0% {
-            height: 45%;
+            height: 50%;
         }
 
         100% {
@@ -1278,7 +1278,7 @@ main.auth-form {
         }
 
         100% {
-            height: 45%;
+            height: 50%;
         }
     }
 

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -126,13 +126,14 @@ ul {
 .header .logo {
     height: calc(var(--primary-header-height) - 6px);
     width: calc(var(--primary-header-height) - 4px);
-    margin-top: 3px;
+    margin-top: 1px;
     border-radius: 50%;
     background-color: var(--tone-4-color);
     font-size: 23px;
     font-weight: bold;
     color: #000;
     user-select: none;
+    border: 2px solid black;
 }
 
 .control-container {

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -1217,12 +1217,6 @@ main.auth-form {
     :root {
         --primary-header-font-size: 26px;
         --tertiary-header-font-size: 20px;
-        --primary-header-height: 34px;
-        --right-button-margin: 6px 0 0 20px;
-        --menu-button-margin: 16px 0 0 0;
-        --primary-container-height: calc(100% - 36px);
-        --search-input-height: 26px;
-        --search-font-size: 18px;
         --study-result-buttons-width: 80%;
         --instructions-font-size: 14px;
         --target-language-font-size: 22px;

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -35,7 +35,6 @@
     --bar-chart-height: 400px;
     --bar-chart-width: 600px;
     --bar-chart-font-size: 14px;
-    --output-container-height: calc(100% - 58px);
     --controls-padding: 14px;
     --study-result-buttons-width: 50%;
     --legend-font-size: 14px;
@@ -55,6 +54,8 @@
     --button-border-bottom: 3px solid var(--accent-color);
     --graph-expand-button-box-shadow: 2px 2px #444;
     --tag-border: 2px solid #333;
+    --primary-panel-margin: 20px 0 0 0;
+    --examples-top-margin: 4px;
 }
 
 html {
@@ -107,10 +108,19 @@ ul {
 
 .header {
     display: grid;
-    grid-template-columns: 50px 1fr 50px;
+    grid-template-columns: 50px 44px 1fr 50px;
     height: var(--primary-header-height);
     text-align: center;
     border-bottom: var(--border);
+}
+
+.header.has-suggestions {
+    height: auto;
+}
+
+.header .logo {
+    height: var(--primary-header-height);
+    width: var(--primary-header-height);
 }
 
 .control-container {
@@ -122,11 +132,12 @@ ul {
 }
 
 .primary-input {
-    width: 80%;
+    width: 100%;
+    max-width: 600px;
     text-align: center;
     height: var(--search-input-height);
     font-size: var(--search-font-size);
-    margin: 10px auto auto 0;
+    margin: 4px auto;
     padding: 0;
     text-align: center;
     border: var(--border);
@@ -140,11 +151,6 @@ ul {
 
 .primary-container {
     height: var(--primary-container-height);
-}
-
-.output-container {
-    height: var(--output-container-height);
-    /* TODO: should probably be grid, but that interacts strangely with cytoscape resizing */
     display: flex;
     max-width: 1300px;
     margin: 0 auto;
@@ -154,6 +160,7 @@ ul {
     width: 50%;
     display: flex;
     flex-direction: column;
+    margin: var(--primary-panel-margin);
 }
 
 .section-container {
@@ -171,15 +178,14 @@ ul {
 }
 
 .word-header .add-button,
-.word-header .check  {
+.word-header .check {
     cursor: pointer;
     float: right;
     margin-right: 20px;
     margin-top: 10px;
 }
 
-#graph,
-#flow-diagram-container {
+#graph {
     height: var(--graph-height);
 }
 
@@ -192,7 +198,7 @@ ul {
 #examples {
     /* avoid scrollbars while animations run, otherwise unnecessary */
     overflow-x: hidden;
-    margin-top: 4px;
+    margin-top: var(--examples-top-margin);
 }
 
 .explore-tabs {
@@ -631,6 +637,7 @@ h2.word-header {
 .right-menu-button-container .check {
     border: 2px solid var(--legend-gradient-start);
 }
+
 .right-menu-button-container .check::after {
     border-color: var(--legend-gradient-start);
 }
@@ -1213,19 +1220,20 @@ main.auth-form {
         --primary-header-height: 34px;
         --right-button-margin: 6px 0 0 20px;
         --menu-button-margin: 16px 0 0 0;
-        --primary-container-height: calc(100% - 35px);
+        --primary-container-height: calc(100% - 36px);
         --search-input-height: 26px;
         --search-font-size: 18px;
-        --output-container-height: calc(100% - 48px);
         --study-result-buttons-width: 80%;
         --instructions-font-size: 14px;
         --target-language-font-size: 22px;
         --controls-padding: 10px;
+        --primary-panel-margin: 0;
+        --examples-top-margin: 14px;
     }
 
     /* TODO(refactor): this is a result of oddities with grid + cytoscape + window resize */
     /* ideally only variables */
-    .output-container {
+    .primary-container {
         display: block;
     }
 
@@ -1238,8 +1246,7 @@ main.auth-form {
     }
 
     /* TODO(refactor): why is this media query using graph-container but the main one uses graph? */
-    #graph-container,
-    #flow-diagram-container {
+    #graph-container {
         height: 55%;
         border-top: var(--border);
     }

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -188,10 +188,6 @@ ul {
     margin: var(--primary-panel-margin);
 }
 
-.walkthrough h1 {
-    text-align: center;
-}
-
 .section-container {
     margin: var(--section-container-margin);
     flex-grow: 1;

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -218,6 +218,10 @@ ul {
     margin-top: var(--examples-top-margin);
 }
 
+#examples .explanation {
+    font-weight: bold;
+}
+
 .explore-tabs {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -54,8 +54,8 @@
     --button-border-bottom: 3px solid var(--accent-color);
     --graph-expand-button-box-shadow: 2px 2px #444;
     --tag-border: 2px solid #333;
-    --primary-panel-margin: 20px 0 0 0;
-    --examples-top-margin: 4px;
+    --examples-top-margin: 14px;
+    --graph-margin-top: 14px;
 }
 
 html {
@@ -112,6 +112,7 @@ ul {
     height: var(--primary-header-height);
     text-align: center;
     border-bottom: var(--border);
+    box-shadow: var(--primary-input-box-shadow);
 }
 
 .header.has-suggestions {
@@ -124,12 +125,12 @@ ul {
 }
 
 .header .logo {
-    height: calc(var(--primary-header-height) - 6px);
-    width: calc(var(--primary-header-height) - 4px);
-    margin-top: 1px;
+    height: calc(var(--primary-header-height) - 10px);
+    width: calc(var(--primary-header-height) - 8px);
+    margin-top: 3px;
     border-radius: 50%;
     background-color: var(--tone-4-color);
-    font-size: 23px;
+    font-size: 21px;
     font-weight: 400;
     color: #000;
     user-select: none;
@@ -173,7 +174,6 @@ ul {
     width: 50%;
     display: flex;
     flex-direction: column;
-    margin: var(--primary-panel-margin);
 }
 
 .section-container {
@@ -200,6 +200,10 @@ ul {
 
 #graph {
     height: var(--graph-height);
+}
+
+#graph-container {
+    margin-top: var(--graph-margin-top);
 }
 
 .flow-explanation {
@@ -1239,8 +1243,8 @@ main.auth-form {
         --instructions-font-size: 14px;
         --target-language-font-size: 22px;
         --controls-padding: 10px;
-        --primary-panel-margin: 0;
         --examples-top-margin: 14px;
+        --graph-margin-top: 0;
     }
 
     /* TODO(refactor): this is a result of oddities with grid + cytoscape + window resize */

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -440,6 +440,7 @@ h2.word-header {
 
 .tags {
     margin-top: 8px;
+    line-height: 26px;
 }
 
 .tag {

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -118,6 +118,11 @@ ul {
     height: auto;
 }
 
+.header h1 {
+    /* keep it centered despite the logo, which gets 44px in the grid template */
+    margin-right: 44px;
+}
+
 .header .logo {
     height: calc(var(--primary-header-height) - 6px);
     width: calc(var(--primary-header-height) - 4px);

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -119,8 +119,15 @@ ul {
 }
 
 .header .logo {
-    height: var(--primary-header-height);
+    height: calc(var(--primary-header-height) - 2px);
     width: var(--primary-header-height);
+    margin-top: 1px;
+    border-radius: 50%;
+    background-color: var(--tone-4-color);
+    font-size: 25px;
+    font-weight: 400;
+    color: #000;
+    user-select: none;
 }
 
 .control-container {
@@ -632,6 +639,11 @@ h2.word-header {
     border-style: solid;
     transform-origin: bottom left;
     transform: rotate(45deg)
+}
+
+.left-menu-button-container,
+.right-menu-button-container {
+    cursor: pointer;
 }
 
 .right-menu-button-container .check {

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -119,13 +119,13 @@ ul {
 }
 
 .header .logo {
-    height: calc(var(--primary-header-height) - 2px);
-    width: var(--primary-header-height);
-    margin-top: 1px;
+    height: calc(var(--primary-header-height) - 6px);
+    width: calc(var(--primary-header-height) - 4px);
+    margin-top: 3px;
     border-radius: 50%;
     background-color: var(--tone-4-color);
-    font-size: 25px;
-    font-weight: 400;
+    font-size: 23px;
+    font-weight: bold;
     color: #000;
     user-select: none;
 }

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -3,8 +3,9 @@
     --primary-font-color: rgba(0, 0, 0, 0.87);
     --primary-font: Roboto, Helvetica, Arial, sans-serif;
     --primary-font-weight: 300;
-    --primary-header-height: 40px;
+    --primary-header-height: 50px;
     --primary-header-font-size: 30px;
+    --header-background-color: #eee7;
     --secondary-header-font-size: 30px;
     --tertiary-header-font-size: 22px;
     --secondary-control-font-size: 14px;
@@ -24,9 +25,11 @@
     --input-background-color: #fff;
     --primary-input-box-shadow: 0 2px 3px 1px #eeee;
     --positive-button-color: #6de200;
-    --right-button-margin: 10px 0 0 20px;
-    --menu-button-margin: 18px 0 0 0;
-    --primary-container-height: calc(100% - 42px);
+    --right-button-height: 22px;
+    /* I was told there would be no math */
+    --right-button-margin: calc((var(--primary-header-height) - var(--right-button-height)) / 2) 0 0 20px;
+    --menu-button-margin: calc(var(--primary-header-height) / 2 - 2px) 0 0 0;
+    --primary-container-height: calc(100% - (var(--primary-header-height) + 2px));
     --legend-height: 20px;
     --graph-height: calc(100% - var(--legend-height) - 4px);
     --section-container-margin: 0 20px;
@@ -113,6 +116,7 @@ ul {
     text-align: center;
     border-bottom: var(--border);
     box-shadow: var(--primary-input-box-shadow);
+    background-color: var(--header-background-color);
 }
 
 .header.has-suggestions {
@@ -122,19 +126,25 @@ ul {
 .header h1 {
     /* keep it centered despite the logo, which gets 44px in the grid template */
     margin-right: 44px;
+    line-height: var(--primary-header-height);
 }
 
 .header .logo {
-    height: calc(var(--primary-header-height) - 10px);
-    width: calc(var(--primary-header-height) - 8px);
-    margin-top: 3px;
+    height: 30px;
+    width: 32px;
+    /* (header height - this element's height - border width*2) all over 2 */
+    margin-top: calc((var(--primary-header-height) - 30px - 6px) / 2);
     border-radius: 50%;
     background-color: var(--tone-4-color);
-    font-size: 21px;
+    font-size: 20px;
     font-weight: 400;
     color: #000;
     user-select: none;
-    border: 2px solid black;
+    border: 3px solid black;
+    cursor: pointer;
+}
+.header .logo.freq {
+    background-color: var(--tone-1-color);
 }
 
 .header.has-suggestions {
@@ -155,12 +165,12 @@ ul {
 }
 
 .primary-input {
-    width: 100%;
+    width: 90%;
     max-width: 600px;
     text-align: center;
     height: var(--search-input-height);
     font-size: var(--search-font-size);
-    margin: 4px auto;
+    margin: 9px auto;
     padding: 0;
     text-align: center;
     border: var(--border);
@@ -574,7 +584,7 @@ h2.word-header {
     height: 30px;
     border: 2px solid;
     border-radius: 4px;
-    margin-top: 2px;
+    margin-top: calc((var(--primary-header-height) - 30px) / 2);
 }
 
 .exit-button::after,
@@ -607,7 +617,7 @@ h2.word-header {
     position: relative;
     display: block;
     width: 20px;
-    height: 22px;
+    height: var(--right-button-height);
     border: 2px solid;
     border-radius: 3px;
     cursor: pointer;
@@ -644,7 +654,7 @@ h2.word-header {
     position: relative;
     display: inline-block;
     width: 22px;
-    height: 22px;
+    height: var(--right-button-height);
     border: 2px solid;
     border-radius: 100px;
     margin: var(--right-button-margin);
@@ -758,7 +768,7 @@ h2.word-header {
     position: absolute;
     border-radius: 3px;
     width: 2px;
-    height: 8px;
+    height: 10px;
     background: currentColor;
     transform: rotate(-45deg);
     top: 10px;
@@ -1224,6 +1234,7 @@ main.auth-form {
 @media (prefers-color-scheme: dark) {
     :root {
         --background-color: #121212;
+        --header-background-color: #121212;
         --primary-font-color: rgba(255, 255, 255, 0.87);
         --border: 1px solid #333;
         --link-font-color: #68aaee;

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -131,6 +131,7 @@ ul {
 
 .header .logo {
     height: 30px;
+    line-height: 30px;
     width: 32px;
     /* (header height - this element's height - border width*2) all over 2 */
     margin-top: calc((var(--primary-header-height) - 30px - 6px) / 2);

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -130,7 +130,7 @@ ul {
     border-radius: 50%;
     background-color: var(--tone-4-color);
     font-size: 23px;
-    font-weight: bold;
+    font-weight: 400;
     color: #000;
     user-select: none;
     border: 2px solid black;

--- a/public/index.html
+++ b/public/index.html
@@ -21,132 +21,131 @@
 </head>
 
 <body>
-    <header class="header">
+    <header id="main-header" class="header">
         <div id="left-menu-button-container" class="left-menu-button-container">
             <i id="left-menu-button" class="menu-button"></i>
         </div>
-        <h1 id="main-header" class="main-header">HanziGraph</h1>
+        <img class="logo" src="/images/hanzigraph-192x192.png"/>
+        <h1 id="text-header" style="display:none">HanziGraph</h1>
+        <form id="hanzi-choose">
+            <input id="hanzi-box" aria-label="Pick a hanzi or word" placeholder="Pick a hanzi or word" type="search"
+                enterkeyhint="search" class="primary-input" autocapitalize="off" autocomplete="off" />
+            <ul id="search-suggestions-container" class="search-suggestions" style="display:none"></ul>
+        </form>
         <div id="right-menu-button-container" class="right-menu-button-container">
             <i id="right-menu-button" class="study-button"></i>
         </div>
     </header>
     <div id="main-app-container" class="primary-container">
-        <div id="query-container" class="control-container">
-            <form id="hanzi-choose">
-                <input id="hanzi-box" aria-label="Pick a hanzi or word" placeholder="Pick a hanzi or word" type="search"
-                    enterkeyhint="search" class="primary-input" autocapitalize="off" autocomplete="off" />
-                <ul id="search-suggestions-container" class="search-suggestions" style="display:none"></ul>
-            </form>
+        <div id="text-container" class="primary-panel">
+            <div id="explore-container" class="section-container">
+                <p style="display:none" id="not-found-message">That word was not found 😞. Please try another, or
+                    change the character set in the menu.</p>
+                <input id="show-pinyin" type="checkbox" style="display:none" />
+                <div id="walkthrough" class="walkthrough" style="display:none">
+                    <!-- i18n :-( -->
+                    <h4>
+                        Learn Chinese by exploring the relationships between characters alongside examples that
+                        illustrate their use.
+                    </h4>
+                    <p>
+                        To get started, click any hanzi or word in the diagram. You can search for hanzi, Chinese
+                        words, or English words.
+                    </p>
+                    <p>
+                        You're viewing <span id="walkthrough-character-set">Simplified</span> characters.
+                        You can choose from Simplified Chinese, Traditional Chinese, Cantonese, or the HSK wordlist
+                        in the menu in the upper left. Or check out <a class="active-link"
+                            href="https://japanesegraph.com">the Japanese version</a>.
+                    </p>
+                    <p>
+                        Just interested in how characters are composed? Check out <a class="active-link"
+                            href="/components">the components tool</a>.
+                    </p>
+                    <p>
+                        <b>This is free and open source software.</b> Check out the code
+                        on <a class="active-link" href="https://github.com/mreichhoff/HanziGraph">GitHub.</a>
+                    </p>
+                    <p>
+                        Most example sentences are human-written, but many are AI-generated. <a class="active-link"
+                            href="https://github.com/mreichhoff/HanziGraph/issues/new/choose">File an issue on
+                            GitHub</a> if you see anything weird.
+                    </p>
+                    <p>
+                        <a class="active-link" id="show-general-faq">See the FAQ for more information.</a>
+                    </p>
+                </div>
+                <div id="examples">
+                </div>
+            </div>
+            <div id="study-container" class="section-container" style="display:none">
+                <div id="study-explain-container" class="explanation">
+                    <h3>Study Mode</h3>
+                    <p id="explain-text">Not sure how this works? <a class="active-link" id="show-study-faq">Learn
+                            more.</a></p>
+                    <p id="hide-study-explanation"><a class="active-link">Hide this message</a></p>
+                </div>
+                <p id="cards-due" class="explanation">
+                    Cards due: <span id="card-due-count" class="emphasized"></span>
+                </p>
+                <p id="study-call-to-action" class="study-call-to-action">
+                    <span id="task-description">What does the text below mean?</span>
+                    <span id="task-complete">Studying complete.<br>You can add more
+                        cards when you see the <span class="add-button"></span> button.</span>
+                </p>
+                <p id="card-question-container" class="card-question"></p>
+                <p id="show-answer-button" class="study-call-to-action active-link">Show Answer</p>
+                <div id="card-answer-container" style="display:none">
+                    <p id="card-answer" class="card-answer"></p>
+                    <ul id="result-buttons">
+                        <li id="wrong-button">✕</li>
+                        <li id="right-button">✔</li>
+                    </ul>
+                    <p id="delete-card-button" class="active-link">Delete this card</p>
+                    <div id="past-performance-container" class="card-detail">
+                        <p id="card-new-message" style="display:none">This is a <span class="emphasized">new</span>
+                            card!</p>
+                        <div id="card-old-message" style="display: none;">
+                            <p>Previous attempts: <span id="card-percentage" class="emphasized"></span> correct.</p>
+                            <p>Right <span id="card-right-count" class="emphasized-but-not-that-emphasized"></span>;
+                                Wrong <span id="card-wrong-count" class="emphasized-but-not-that-emphasized"></span>.
+                            </p>
+                            <p id="card-added-time-container">Card added: <span
+                                    class="emphasized-but-not-that-emphasized" id="card-added-time"></span></p>
+                        </div>
+                    </div>
+                    <div id="related-cards-container" class="card-detail" style="display:none">
+                        Other cards with <span class="emphasized-target" id="related-card-query"></span>:
+                        <div id="related-cards" class="related-cards"></div>
+                    </div>
+                </div>
+            </div>
+            <div id="graph-expander" class="graph-expander" style="display: none;">
+                <span class="big-up-arrow"></span>
+            </div>
         </div>
-        <div id="data-container" class="output-container">
-            <div id="text-container" class="primary-panel">
-                <div id="explore-container" class="section-container">
-                    <p style="display:none" id="not-found-message">That word was not found 😞. Please try another, or
-                        change the character set in the menu.</p>
-                    <input id="show-pinyin" type="checkbox" style="display:none" />
-                    <div id="walkthrough" class="walkthrough" style="display:none">
-                        <!-- i18n :-( -->
-                        <h4>
-                            Learn Chinese by exploring the relationships between characters alongside examples that
-                            illustrate their use.
-                        </h4>
-                        <p>
-                            To get started, click any hanzi or word in the diagram. You can search for hanzi, Chinese
-                            words, or English words.
-                        </p>
-                        <p>
-                            You're viewing <span id="walkthrough-character-set">Simplified</span> characters.
-                            You can choose from Simplified Chinese, Traditional Chinese, Cantonese, or the HSK wordlist
-                            in the menu in the upper left. Or check out <a class="active-link"
-                                href="https://japanesegraph.com">the Japanese version</a>.
-                        </p>
-                        <p>
-                            Just interested in how characters are composed? Check out <a class="active-link"
-                                href="/components">the components tool</a>.
-                        </p>
-                        <p>
-                            <b>This is free and open source software.</b> Check out the code
-                            on <a class="active-link" href="https://github.com/mreichhoff/HanziGraph">GitHub.</a>
-                        </p>
-                        <p>
-                            Most example sentences are human-written, but many are AI-generated. <a class="active-link"
-                                href="https://github.com/mreichhoff/HanziGraph/issues/new/choose">File an issue on
-                                GitHub</a> if you see anything weird.
-                        </p>
-                        <p>
-                            <a class="active-link" id="show-general-faq">See the FAQ for more information.</a>
-                        </p>
-                    </div>
-                    <div id="examples">
+        <div id="graph-container" class="primary-panel">
+            <div class="legend-container">
+                <div id="collapse-graph"><span class="down-arrow"></span></div>
+                <div id="freq-legend" style="display:none" class="legend">
+                    Common
+                    <div id="level-container"></div>
+                    Uncommon
+                </div>
+                <div id="tone-legend" class="legend">
+                    <div>Tone:
+                        <span class="tone1">1st</span>
+                        <span class="tone2">2nd</span>
+                        <span class="tone3">3rd</span>
+                        <span class="tone4">4th</span>
+                        <span class="tone5">Neutral</span>
                     </div>
                 </div>
-                <div id="study-container" class="section-container" style="display:none">
-                    <div id="study-explain-container" class="explanation">
-                        <h3>Study Mode</h3>
-                        <p id="explain-text">Not sure how this works? <a class="active-link" id="show-study-faq">Learn
-                                more.</a></p>
-                        <p id="hide-study-explanation"><a class="active-link">Hide this message</a></p>
-                    </div>
-                    <p id="cards-due" class="explanation">
-                        Cards due: <span id="card-due-count" class="emphasized"></span>
-                    </p>
-                    <p id="study-call-to-action" class="study-call-to-action">
-                        <span id="task-description">What does the text below mean?</span>
-                        <span id="task-complete">Studying complete.<br>You can add more
-                            cards when you see the <span class="add-button"></span> button.</span>
-                    </p>
-                    <p id="card-question-container" class="card-question"></p>
-                    <p id="show-answer-button" class="study-call-to-action active-link">Show Answer</p>
-                    <div id="card-answer-container" style="display:none">
-                        <p id="card-answer" class="card-answer"></p>
-                        <ul id="result-buttons">
-                            <li id="wrong-button">✕</li>
-                            <li id="right-button">✔</li>
-                        </ul>
-                        <p id="delete-card-button" class="active-link">Delete this card</p>
-                        <div id="past-performance-container" class="card-detail">
-                            <p id="card-new-message" style="display:none">This is a <span class="emphasized">new</span> card!</p>
-                            <div id="card-old-message" style="display: none;">
-                                <p>Previous attempts: <span id="card-percentage" class="emphasized"></span> correct.</p>
-                                <p>Right <span id="card-right-count" class="emphasized-but-not-that-emphasized"></span>; Wrong <span id="card-wrong-count" class="emphasized-but-not-that-emphasized"></span>.
-                                </p>
-                                <p id="card-added-time-container">Card added: <span class="emphasized-but-not-that-emphasized" id="card-added-time"></span></p>
-                            </div>
-                        </div>
-                        <div id="related-cards-container" class="card-detail" style="display:none">
-                            Other cards with <span class="emphasized-target" id="related-card-query"></span>:
-                            <div id="related-cards" class="related-cards"></div>
-                        </div>
-                    </div>
-                </div>
-                <div id="graph-expander" class="graph-expander" style="display: none;">
-                    <span class="big-up-arrow"></span>
-                </div>
+                <a class="legend-switch-button" id="switch-legend">
+                    <span class="right-arrow"></span>
+                </a>
             </div>
-            <div id="graph-container" class="primary-panel">
-                <div class="legend-container">
-                    <div id="collapse-graph"><span class="down-arrow"></span></div>
-                    <div id="freq-legend" style="display:none" class="legend">
-                        Common
-                        <div id="level-container"></div>
-                        Uncommon
-                    </div>
-                    <div id="tone-legend" class="legend">
-                        <div>Tone:
-                            <span class="tone1">1st</span>
-                            <span class="tone2">2nd</span>
-                            <span class="tone3">3rd</span>
-                            <span class="tone4">4th</span>
-                            <span class="tone5">Neutral</span>
-                        </div>
-                    </div>
-                    <a class="legend-switch-button" id="switch-legend">
-                        <span class="right-arrow"></span>
-                    </a>
-                </div>
-                <div id="graph" class="graph"></div>
-            </div>
-            <div id="flow-diagram-container" class="primary-panel" style="display:none"></div>
+            <div id="graph" class="graph"></div>
         </div>
     </div>
     <div id="stats-container" style="display:none">
@@ -275,7 +274,8 @@
                 system, like Anki.
             </p>
             <h3>Where are the flashcards stored?</h3>
-            <p>If you are signed in, the data is stored on our servers, and synced across any other device where you sign in.
+            <p>If you are signed in, the data is stored on our servers, and synced across any other device where you
+                sign in.
                 If you are not signed in, all data for the site is stored in <a
                     href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage">localStorage</a>.
                 It

--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
         <div id="left-menu-button-container" class="left-menu-button-container">
             <i id="left-menu-button" class="menu-button"></i>
         </div>
-        <img class="logo" src="/images/hanzigraph-192x192.png"/>
+        <div id="header-logo" class="logo">汉</div>
         <h1 id="text-header" style="display:none">HanziGraph</h1>
         <form id="hanzi-choose">
             <input id="hanzi-box" aria-label="Pick a hanzi or word" placeholder="Pick a hanzi or word" type="search"

--- a/public/index.html
+++ b/public/index.html
@@ -44,32 +44,43 @@
                 <input id="show-pinyin" type="checkbox" style="display:none" />
                 <div id="walkthrough" class="walkthrough" style="display:none">
                     <!-- i18n :-( -->
+                    <h1>HanziGraph</h1>
                     <h4>
                         Learn Chinese by exploring the relationships between characters alongside examples that
                         illustrate their use.
                     </h4>
                     <p>
-                        To get started, click any hanzi or word in the diagram. You can search for hanzi, Chinese
-                        words, or English words.
+                        Click or tap any hanzi, anywhere, or search in
+                        <span class="emphasized-but-not-that-emphasized">Chinese</span>
+                        or <span class="emphasized-but-not-that-emphasized">English</span>.
                     </p>
                     <p>
-                        You're viewing <span id="walkthrough-character-set">Simplified</span> characters.
-                        You can choose from Simplified Chinese, Traditional Chinese, Cantonese, or the HSK wordlist
-                        in the menu in the upper left. Or check out <a class="active-link"
-                            href="https://japanesegraph.com">the Japanese version</a>.
+                        You're viewing <span class="emphasized-but-not-that-emphasized"
+                            id="walkthrough-character-set">Simplified</span> characters.
+                        Check the menu for more options, or check out <a class="active-link"
+                            href="https://japanesegraph.com">the <span
+                                class="emphasized-but-not-that-emphasized">Japanese</span> version</a>.
+                    </p>
+                    <p>
+                        <span class="emphasized-but-not-that-emphasized">This is free and open source software.</span>
+                        Check out the code
+                        on <a class="active-link" href="https://github.com/mreichhoff/HanziGraph">GitHub.</a>
+                        <a href="https://github.com/mreichhoff/HanziGraph">
+                            <svg stroke="currentColor" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"
+                                fill="currentColor" style="width: 28px;height:28px">
+                                <title>More information on GitHub</title>
+                                <path xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd"
+                                    d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" />
+                            </svg>
+                        </a>
+                    </p>
+                    <p>
+                        Most example sentences are human-written, but many are AI-generated. <a class="active-link"
+                            href="https://github.com/mreichhoff/HanziGraph/issues/new/choose">Let us know</a> if you see anything weird.
                     </p>
                     <p>
                         Just interested in how characters are composed? Check out <a class="active-link"
                             href="/components">the components tool</a>.
-                    </p>
-                    <p>
-                        <b>This is free and open source software.</b> Check out the code
-                        on <a class="active-link" href="https://github.com/mreichhoff/HanziGraph">GitHub.</a>
-                    </p>
-                    <p>
-                        Most example sentences are human-written, but many are AI-generated. <a class="active-link"
-                            href="https://github.com/mreichhoff/HanziGraph/issues/new/choose">File an issue on
-                            GitHub</a> if you see anything weird.
                     </p>
                     <p>
                         <a class="active-link" id="show-general-faq">See the FAQ for more information.</a>

--- a/public/index.html
+++ b/public/index.html
@@ -44,7 +44,6 @@
                 <input id="show-pinyin" type="checkbox" style="display:none" />
                 <div id="walkthrough" class="walkthrough" style="display:none">
                     <!-- i18n :-( -->
-                    <h1>HanziGraph</h1>
                     <h4>
                         Learn Chinese by exploring the relationships between characters alongside examples that
                         illustrate their use.

--- a/public/js/modules/graph.js
+++ b/public/js/modules/graph.js
@@ -8,6 +8,8 @@ const switchLegend = document.getElementById('switch-legend');
 
 const freqLegend = document.getElementById('freq-legend');
 const toneLegend = document.getElementById('tone-legend');
+// TODO: shared with options...could de-couple with custom events, but who has the time
+const headerLogo = document.getElementById('header-logo');
 
 let cy = null;
 let currentPath = [];
@@ -367,33 +369,40 @@ let showingGraph = true;
 let pendingResizeTimeout = null;
 let dirty = null;
 
+function toggleColorCodeMode() {
+    if(colorCodeMode === colorCodeModes.tones) {
+        colorCodeMode = colorCodeModes.frequency;
+        freqLegend.removeAttribute('style');
+        freqLegend.classList.add('slide-in');
+        toneLegend.style.display = 'none';
+        toneLegend.classList.remove('slide-in');
+        headerLogo.classList.add('freq');
+    } else {
+        colorCodeMode = colorCodeModes.tones;
+        toneLegend.removeAttribute('style');
+        toneLegend.classList.add('slide-in');
+        freqLegend.style.display = 'none';
+        freqLegend.classList.remove('slide-in');
+        headerLogo.classList.remove('freq');
+    }
+    updateColorScheme();
+}
+
 function toggleColorCodeVisibility() {
     if (getActiveGraph().disableToneColors) {
         colorCodeMode = colorCodeModes.frequency;
         freqLegend.removeAttribute('style');
         toneLegend.style.display = 'none';
         switchLegend.style.display = 'none';
+        headerLogo.classList.add('freq');
+    } else {
+        headerLogo.addEventListener('click', toggleColorCodeMode);
     }
 }
 
 function initialize() {
     toggleColorCodeVisibility();
-    switchLegend.addEventListener('click', function() {
-        if(colorCodeMode === colorCodeModes.tones) {
-            colorCodeMode = colorCodeModes.frequency;
-            freqLegend.removeAttribute('style');
-            freqLegend.classList.add('slide-in');
-            toneLegend.style.display = 'none';
-            toneLegend.classList.remove('slide-in');
-        } else {
-            colorCodeMode = colorCodeModes.tones;
-            toneLegend.removeAttribute('style');
-            toneLegend.classList.add('slide-in');
-            freqLegend.style.display = 'none';
-            freqLegend.classList.remove('slide-in');
-        }
-        updateColorScheme();
-    });
+    switchLegend.addEventListener('click', toggleColorCodeMode);
     document.addEventListener('graph-update', function (event) {
         buildGraph(event.detail);
     });

--- a/public/js/modules/options.js
+++ b/public/js/modules/options.js
@@ -6,6 +6,7 @@ const showPinyinCheckbox = document.getElementById('show-pinyin');
 const togglePinyinLabel = document.getElementById('toggle-pinyin-label');
 const offlineItem = document.getElementById('offline-item');
 const offlineButton = document.getElementById('offline-button');
+const headerLogo = document.getElementById('header-logo');
 
 let hskLegend = ['HSK1', 'HSK2', 'HSK3', 'HSK4', 'HSK5', 'HSK6'];
 let freqLegend = ['Top1k', 'Top2k', 'Top4k', 'Top7k', 'Top10k', '>10k'];
@@ -50,7 +51,8 @@ const graphOptions = {
         type: 'frequency',
         hasCoverage: 'all',
         collocationsPath: 'data/traditional/collocations',
-        englishPath: 'data/traditional/english'
+        englishPath: 'data/traditional/english',
+        logoCharacter: '漢'
     },
     cantonese: {
         display: 'Cantonese',
@@ -65,7 +67,8 @@ const graphOptions = {
         defaultHanzi: ["我", "哥", "路", "細"],
         transcriptionName: 'jyutping',
         type: 'frequency',
-        disableToneColors: true
+        disableToneColors: true,
+        logoCharacter: '漢'
     }
 };
 let activeGraphKey = 'simplified';
@@ -104,7 +107,10 @@ function setTranscriptionLabel() {
     }
 }
 const walkthroughCharacterSet = document.getElementById('walkthrough-character-set');
-function updateWalkthrough() {
+function updateGraphDisplayText() {
+    if (graphOptions[activeGraphKey].logoCharacter) {
+        headerLogo.innerText = graphOptions[activeGraphKey].logoCharacter;
+    }
     walkthroughCharacterSet.innerText = graphOptions[activeGraphKey].display;
 }
 function initialize() {
@@ -132,7 +138,7 @@ function initialize() {
         window.wordSet = getWordLevelsFromGraph(window.hanzi);
     }
     setTranscriptionLabel();
-    updateWalkthrough();
+    updateGraphDisplayText();
     setupMakeOfflineButton();
 }
 let loadingIndicatorInterval = null;

--- a/public/js/modules/search-suggestions-worker.js
+++ b/public/js/modules/search-suggestions-worker.js
@@ -1,4 +1,7 @@
 const maxRecommendations = 12;
+// allow more matches for pinyin, given that we support tone-less queries,
+// where you're far more likely to have many matches.
+const maxPinyinMatches = 25;
 let trie = {
     children: {},
     words: []
@@ -107,11 +110,15 @@ function buildTries(wordSet, definitions) {
                 if (!(joinedPinyin in pinyinMap)) {
                     pinyinMap[joinedPinyin] = new Set();
                 }
-                pinyinMap[joinedPinyin].add(word);
+                if (pinyinMap[joinedPinyin].size < maxPinyinMatches) {
+                    pinyinMap[joinedPinyin].add(word);
+                }
                 if (!(removedTones in pinyinMap)) {
                     pinyinMap[removedTones] = new Set();
                 }
-                pinyinMap[removedTones].add(word);
+                if (pinyinMap[removedTones].size < maxPinyinMatches) {
+                    pinyinMap[removedTones].add(word);
+                }
                 for (const character of joinedPinyin) {
                     if (!(character in pinyinNode.children)) {
                         pinyinNode.children[character] = { children: {}, words: [] }

--- a/public/js/modules/search.js
+++ b/public/js/modules/search.js
@@ -1,9 +1,11 @@
 import { hanziBox, notFoundElement } from "./dom";
 import { getActiveGraph, getPartition } from "./options";
+import { switchToState, stateKeys } from "./ui-orchestrator";
 
 let jiebaCut = null;
 let searchSuggestionsWorker = null;
 let pinyinMap = {};
+const mainHeader = document.getElementById('main-header');
 const searchSuggestionsContainer = document.getElementById('search-suggestions-container');
 
 function looksLikeEnglish(value) {
@@ -126,6 +128,7 @@ function renderSearchSuggestions(query, suggestions, tokens, container) {
         clearSuggestions();
         return;
     }
+    mainHeader.classList.add('has-suggestions');
     let priorWordsForDisplay = '';
     let allButLastToken = [];
     if (isMultiWord) {
@@ -147,6 +150,7 @@ function renderSearchSuggestions(query, suggestions, tokens, container) {
             document.dispatchEvent(new CustomEvent('graph-update', { detail: suggestion }));
             document.dispatchEvent(new CustomEvent('explore-update', { detail: { words: [suggestion] } }));
             clearSuggestions();
+            switchToState(stateKeys.main);
         });
     }
     for (const suggestion of suggestions['tokenized']) {
@@ -157,11 +161,13 @@ function renderSearchSuggestions(query, suggestions, tokens, container) {
         item.addEventListener('mousedown', function () {
             multiWordSearch(priorWordsForDisplay + suggestion, allButLastToken.concat(suggestion));
             clearSuggestions();
+            switchToState(stateKeys.main);
         });
     }
     container.removeAttribute('style');
 }
 function clearSuggestions() {
+    mainHeader.classList.remove('has-suggestions');
     searchSuggestionsContainer.style.display = 'none';
 }
 

--- a/public/js/modules/search.js
+++ b/public/js/modules/search.js
@@ -12,72 +12,6 @@ function looksLikeEnglish(value) {
     return /^[\x00-\xFF]*$/.test(value);
 }
 
-// lol
-function vetCandidate(candidate) {
-    if (!(candidate in wordSet)) {
-        if (!isNaN(candidate)) {
-            // it's not not a number, so ignore it.
-            return [{ word: candidate, ignore: true }];
-        }
-        if (looksLikeEnglish(candidate)) {
-            // it's ascii, not Chinese, so ignore it
-            // TODO: just use ! in_chinese_char_range 
-            return [{ word: candidate, ignore: true }];
-        }
-        // For two character words not in the wordSet, just add individual characters.
-        if (candidate.length === 2) {
-            if (candidate[0] in wordSet && candidate[1] in wordSet) {
-                return [candidate[0], candidate[1]];
-            }
-        } else if (candidate.length === 3) {
-            let first = candidate[0];
-            let last = candidate.substring(1);
-            if (first in wordSet && last in wordSet) {
-                return [first, last];
-            }
-            first = candidate.substring(0, 2);
-            last = candidate.substring(2);
-            if (first in wordSet && last in wordSet) {
-                return [first, last];
-            }
-            if (candidate[0] in wordSet && candidate[1] in wordSet && candidate[2] in wordSet) {
-                return [candidate[0], candidate[1], candidate[2]];
-            }
-        } else if (candidate.length === 4) {
-            let first = candidate.substring(0, 2);
-            let last = candidate.substring(2);
-            if (first in wordSet && last in wordSet) {
-                return [first, last]
-            }
-            if (candidate[0] in wordSet && candidate[1] in wordSet && candidate[2] in wordSet && candidate[3] in wordSet) {
-                return [candidate[0], candidate[1], candidate[2], candidate[3]];
-            }
-        }
-        // it's not a number, it's not english or something, it's not trivially repaired...ignore
-        return [{ word: candidate, ignore: true }];
-    }
-    return [candidate];
-}
-
-function segment(text, locale) {
-    locale = locale || getActiveGraph().locale;
-    if (!jiebaCut && (!Intl || !Intl.Segmenter)) {
-        return [text];
-    }
-    text = text.replace(/[？。！，·【】；：、?,'!]/g, '');
-    let candidates = [];
-    let result = [];
-    if (jiebaCut) {
-        candidates = jiebaCut(text, true);
-    } else {
-        const segmenter = new Intl.Segmenter(locale, { granularity: "word" });
-        candidates = Array.from(segmenter.segment(text)).map(x => x.segment);
-    }
-    for (const candidate of candidates) {
-        result.push(...(vetCandidate(candidate)));
-    }
-    return result;
-}
 function suggestSearches() {
     const partialSearch = hanziBox.value;
     if (!partialSearch) {
@@ -85,10 +19,9 @@ function suggestSearches() {
     }
     // For now, don't suggest based on english words, but do suggest for pinyin.
     // Either way, send it off to the worker.
-    const tokens = segment(partialSearch, getActiveGraph().locale);
     searchSuggestionsWorker.postMessage({
         type: 'query',
-        payload: { query: partialSearch.trim(), tokens: tokens }
+        payload: { query: partialSearch.trim(), locale: getActiveGraph().locale }
     });
 }
 function handleWorkerMessage(message) {
@@ -102,15 +35,13 @@ function handleWorkerMessage(message) {
     if (!message.data.query || message.data.query !== hanziBox.value) {
         return;
     }
+    if(message.data.type === 'tokenize') {
+        multiWordSearch(message.data.query, message.data.tokens, message.data.mode)
+        return;
+    }
     renderSearchSuggestions(message.data.query, message.data.suggestions, message.data.tokens, searchSuggestionsContainer);
 }
 
-function renderExplanationItem(text, container) {
-    let instructionsItem = document.createElement('li');
-    instructionsItem.classList.add('suggestions-explanation');
-    instructionsItem.innerText = text;
-    container.appendChild(instructionsItem);
-}
 function renderSuggestion(priorWordsForDisplay, suggestion, container) {
     let prior = document.createElement('span');
     prior.innerText = priorWordsForDisplay;
@@ -187,12 +118,6 @@ async function initialize(term, mode) {
     const ensureLoaded = new Promise(ready => searchSuggestionsWorker.addEventListener("message", ready, { once: true }));
     hanziBox.addEventListener('input', suggestSearches);
     hanziBox.addEventListener('blur', clearSuggestions);
-    // TODO: get all jieba use off the main thread
-    const { default: init,
-        cut,
-    } = await import("/js/external/jieba_rs_wasm.js");
-    await init();
-    jiebaCut = cut;
     if (term) {
         await ensureLoaded;
         search(term, getActiveGraph().locale, (mode || 'explore'));
@@ -259,7 +184,13 @@ function search(value, locale, mode) {
             });
         return;
     }
-    multiWordSearch(value, segment(value, locale), mode)
+    searchSuggestionsWorker.postMessage({
+        type: 'tokenize',
+        // ask the worker to tokenize, and then on response run the multi-word search
+        // TODO: if we'd ever have other actions besides a multi-word search, we would have to pass
+        // the action along here or something
+        payload: { query: value, locale, mode }
+    });
 }
 
 export { search, initialize, looksLikeEnglish }

--- a/public/js/modules/ui-orchestrator.js
+++ b/public/js/modules/ui-orchestrator.js
@@ -15,8 +15,12 @@ const graphExpander = document.getElementById('graph-expander');
 const explorePane = document.getElementById('explore-container');
 const studyPane = document.getElementById('study-container');
 
+const searchForm = document.getElementById('hanzi-choose');
+const textHeader = document.getElementById('text-header');
+
 const containers = [mainAppContainer, statsContainer, faqContainer, menuContainer];
 const panes = [explorePane, studyPane];
+const midHeaderOptions = [textHeader, searchForm];
 
 // TODO(refactor): I'm gonna go out on a limb and say there's a better way...
 const stateKeys = {
@@ -34,6 +38,7 @@ const states = {
         activeContainer: mainAppContainer,
         activePane: explorePane,
         leftState: 'menu',
+        activeMidHeader: searchForm,
         rightState: 'study',
         paneAnimation: 'slide-in'
     },
@@ -43,6 +48,7 @@ const states = {
         activeContainer: mainAppContainer,
         activePane: studyPane,
         leftState: 'menu',
+        activeMidHeader: searchForm,
         rightState: 'main',
         paneAnimation: 'slide-in'
     },
@@ -51,6 +57,7 @@ const states = {
         activeContainer: faqContainer,
         statePreserving: true,
         leftState: 'previous',
+        activeMidHeader: textHeader,
         animation: 'slide-in'
     },
     stats: {
@@ -58,6 +65,7 @@ const states = {
         activeContainer: statsContainer,
         statePreserving: true,
         leftState: 'main',
+        activeMidHeader: textHeader,
         animation: 'slide-in'
     },
     menu: {
@@ -65,6 +73,7 @@ const states = {
         activeContainer: menuContainer,
         statePreserving: true,
         leftState: 'previous',
+        activeMidHeader: textHeader,
         animation: 'slide-in'
     }
 };
@@ -85,6 +94,13 @@ function switchToState(state) {
         if (container.id !== stateConfig.activeContainer.id) {
             container.style.display = 'none';
             container.dispatchEvent(new Event('hidden'));
+        }
+    }
+    for (const midHeaderOption of midHeaderOptions) {
+        if(midHeaderOption.id !== stateConfig.activeMidHeader.id) {
+            midHeaderOption.style.display = 'none';
+        } else {
+            midHeaderOption.removeAttribute('style');
         }
     }
     stateConfig.activeContainer.removeAttribute('style');


### PR DESCRIPTION
This change gives more space to definitions and examples, which is particularly important on smaller screens. A logo is substituted for the text header in the main view, and the text header is re-shown (without the search form) in menu and stats views. TODO: is the logo right, or would an abbreviated text header be better?