### PR TITLE
Make multi-word explanation style clear

### DIFF
--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -195,6 +195,10 @@ ul {
     margin-top: 4px;
 }
 
+#examples .explanation {
+    font-weight: bold;
+}
+
 .explore-tabs {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;


### PR DESCRIPTION
With some brittle CSS, oh well