### PR TITLE
Move jieba off the main thread

### DIFF
--- a/public/js/modules/search.js
+++ b/public/js/modules/search.js
@@ -10,72 +10,6 @@ function looksLikeEnglish(value) {
     return /^[\x00-\xFF]*$/.test(value);
 }
 
-// lol
-function vetCandidate(candidate) {
-    if (!(candidate in wordSet)) {
-        if (!isNaN(candidate)) {
-            // it's not not a number, so ignore it.
-            return [{ word: candidate, ignore: true }];
-        }
-        if (looksLikeEnglish(candidate)) {
-            // it's ascii, not Chinese, so ignore it
-            // TODO: just use ! in_chinese_char_range 
-            return [{ word: candidate, ignore: true }];
-        }
-        // For two character words not in the wordSet, just add individual characters.
-        if (candidate.length === 2) {
-            if (candidate[0] in wordSet && candidate[1] in wordSet) {
-                return [candidate[0], candidate[1]];
-            }
-        } else if (candidate.length === 3) {
-            let first = candidate[0];
-            let last = candidate.substring(1);
-            if (first in wordSet && last in wordSet) {
-                return [first, last];
-            }
-            first = candidate.substring(0, 2);
-            last = candidate.substring(2);
-            if (first in wordSet && last in wordSet) {
-                return [first, last];
-            }
-            if (candidate[0] in wordSet && candidate[1] in wordSet && candidate[2] in wordSet) {
-                return [candidate[0], candidate[1], candidate[2]];
-            }
-        } else if (candidate.length === 4) {
-            let first = candidate.substring(0, 2);
-            let last = candidate.substring(2);
-            if (first in wordSet && last in wordSet) {
-                return [first, last]
-            }
-            if (candidate[0] in wordSet && candidate[1] in wordSet && candidate[2] in wordSet && candidate[3] in wordSet) {
-                return [candidate[0], candidate[1], candidate[2], candidate[3]];
-            }
-        }
-        // it's not a number, it's not english or something, it's not trivially repaired...ignore
-        return [{ word: candidate, ignore: true }];
-    }
-    return [candidate];
-}
-
-function segment(text, locale) {
-    locale = locale || getActiveGraph().locale;
-    if (!jiebaCut && (!Intl || !Intl.Segmenter)) {
-        return [text];
-    }
-    text = text.replace(/[？。！，·【】；：、?,'!]/g, '');
-    let candidates = [];
-    let result = [];
-    if (jiebaCut) {
-        candidates = jiebaCut(text, true);
-    } else {
-        const segmenter = new Intl.Segmenter(locale, { granularity: "word" });
-        candidates = Array.from(segmenter.segment(text)).map(x => x.segment);
-    }
-    for (const candidate of candidates) {
-        result.push(...(vetCandidate(candidate)));
-    }
-    return result;
-}
 function suggestSearches() {
     const partialSearch = hanziBox.value;
     if (!partialSearch) {
@@ -83,10 +17,9 @@ function suggestSearches() {
     }
     // For now, don't suggest based on english words, but do suggest for pinyin.
     // Either way, send it off to the worker.
-    const tokens = segment(partialSearch, getActiveGraph().locale);
     searchSuggestionsWorker.postMessage({
         type: 'query',
-        payload: { query: partialSearch.trim(), tokens: tokens }
+        payload: { query: partialSearch.trim(), locale: getActiveGraph().locale }
     });
 }
 function handleWorkerMessage(message) {
@@ -100,15 +33,13 @@ function handleWorkerMessage(message) {
     if (!message.data.query || message.data.query !== hanziBox.value) {
         return;
     }
+    if(message.data.type === 'tokenize') {
+        multiWordSearch(message.data.query, message.data.tokens, message.data.mode)
+        return;
+    }
     renderSearchSuggestions(message.data.query, message.data.suggestions, message.data.tokens, searchSuggestionsContainer);
 }
 
-function renderExplanationItem(text, container) {
-    let instructionsItem = document.createElement('li');
-    instructionsItem.classList.add('suggestions-explanation');
-    instructionsItem.innerText = text;
-    container.appendChild(instructionsItem);
-}
 function renderSuggestion(priorWordsForDisplay, suggestion, container) {
     let prior = document.createElement('span');
     prior.innerText = priorWordsForDisplay;
@@ -181,12 +112,6 @@ async function initialize(term, mode) {
     const ensureLoaded = new Promise(ready => searchSuggestionsWorker.addEventListener("message", ready, { once: true }));
     hanziBox.addEventListener('input', suggestSearches);
     hanziBox.addEventListener('blur', clearSuggestions);
-    // TODO: get all jieba use off the main thread
-    const { default: init,
-        cut,
-    } = await import("/js/external/jieba_rs_wasm.js");
-    await init();
-    jiebaCut = cut;
     if (term) {
         await ensureLoaded;
         search(term, getActiveGraph().locale, (mode || 'explore'));
@@ -253,7 +178,13 @@ function search(value, locale, mode) {
             });
         return;
     }
-    multiWordSearch(value, segment(value, locale), mode)
+    searchSuggestionsWorker.postMessage({
+        type: 'tokenize',
+        // ask the worker to tokenize, and then on response run the multi-word search
+        // TODO: if we'd ever have other actions besides a multi-word search, we would have to pass
+        // the action along here or something
+        payload: { query: value, locale, mode }
+    });
 }
 
 export { search, initialize, looksLikeEnglish }


### PR DESCRIPTION
This prevents UI jank while typing, as previously tokenization was happening on the main thread. This does increase search suggestion worker memory, however, and upcoming commits will need to find a way to decrease that.

The incompatibility between CEDICT and jieba/Intl stuff remains a TODO (especially with the nasty vetCandidate function).