### PR TITLE
Fix login header; make (minimal) benefits clear

### DIFF
--- a/public/js/modules/auth.js
+++ b/public/js/modules/auth.js
@@ -45,11 +45,13 @@ document.getElementById('register').addEventListener('submit', function (event) 
 });
 document.getElementById('register-link').addEventListener('click', function () {
     document.getElementById('signin').style.display = 'none';
+    document.getElementById('login-header').innerText = "Register";
     document.getElementById('register').removeAttribute('style');
     document.getElementById('error-message').style.visibility = 'hidden';
 });
 document.getElementById('signin-link').addEventListener('click', function () {
     document.getElementById('register').style.display = 'none';
+    document.getElementById('login-header').innerText = "Sign in";
     document.getElementById('signin').removeAttribute('style');
     document.getElementById('error-message').style.visibility = 'hidden';
 });

--- a/public/login.html
+++ b/public/login.html
@@ -15,7 +15,8 @@
 <body>
     <header class="header">
         <div class="exit-container"><a href="/"><i id="faq-exit-button" class="exit-button"></i></a></div>
-        <h1 class="main-header">Sign in or Register</h1>
+        <div id="header-logo" class="logo freq">汉</div>
+        <h1 id="login-header" class="main-header">Sign in</h1>
         <div class="stats-container"></div>
     </header>
     <main class="auth-form">
@@ -44,6 +45,8 @@
             <p id="forgot-password">Forgot your password?</p>
         </form>
         <form id="register" style="display: none;">
+            <p style="margin-top:0"><span class="emphasized-but-not-that-emphasized">Note: </span> An account is not
+                required. It only allows your flash cards and study stats to be synced across devices.</p>
             <ul>
                 <li>
                     <label for="register-email">


### PR DESCRIPTION
The prior commit's continued abuse of CSS grid caused more wrapping than was previously present (and it was already bad).

It's also good to make clear to users that registration is not required, and that its only benefits are with syncing across devices. (which also keeps in line with the static website spirit of the app).