### PR TITLE
Hack around android keyboard oddities

### DIFF
--- a/public/js/modules/main.js
+++ b/public/js/modules/main.js
@@ -101,7 +101,6 @@ Promise.all(
         // This in very rare cases could cause cause a skipped re-layout on window size change
         // but that should be rare.
         document.dispatchEvent(new Event('skip-graph-resize'));
-        // preventDefault() doesn't stop this blur event on ios, but does on android.
         hanziBox.blur();
     });
 

--- a/public/js/modules/main.js
+++ b/public/js/modules/main.js
@@ -95,7 +95,22 @@ Promise.all(
         event.preventDefault();
         search(hanziBox.value);
         switchToState(stateKeys.main);
+
+        // we're about to force a blur, which should hide the soft keyboard on android or ios
+        // but in some cases, the keyboard hiding triggers a resize, so you get an annoying graph re-render.
+        // This in very rare cases could cause cause a skipped re-layout on window size change
+        // but that should be rare.
+        document.dispatchEvent(new Event('skip-graph-resize'));
+        // preventDefault() doesn't stop this blur event on ios, but does on android.
+        hanziBox.blur();
     });
+
+    // similar to the blur logic above, the soft keyboard will show. Skip the next resize event.
+    // Same edge case with possible skipped 'real' resizes, but that should be very rare.
+    hanziBox.addEventListener('focus', function () {
+        document.dispatchEvent(new Event('skip-graph-resize'));
+    });
+
     // TODO(refactor): this belongs in explore rather than main?
     let oldState = readExploreState();
     // precedence goes to the direct URL entered first, then to anything hanging around in history, then localstorage.


### PR DESCRIPTION
It's unclear if this occurs on all android versions and all browsers vs specific chrome versions or something. But by default, the submit preventDefault seems to not cause the input to trigger a blur, and the on-screen keyboard triggers window resize events. Ideally this change is safe for other platforms where this isn't occurring as well.