### PR TITLE
Add popover menu, replacing add-all pattern

### DIFF
--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -65,6 +65,9 @@
     --walkthrough-smallest-header-font-size: 18px;
     --walkthrough-top-margin: 80px;
     --walkthrough-header-text-align: left;
+    --popover-background-color: #eee;
+    --popover-font-color: black;
+    --menu-popover-border: 3px solid #3333;
 }
 
 html {
@@ -241,7 +244,38 @@ input[type="search"] {
 }
 
 .sentence-container {
+    /* 22px for the add button, plus its margin of 28, uh...and I guess 20 more... */
     width: calc(100% - 70px);
+}
+
+#menu-popover {
+    width: 240px;
+    background-color: var(--popover-background-color);
+    color: var(--popover-font-color);
+    position: absolute;
+    inset: unset;
+    border-radius: 16px;
+    border: var(--menu-popover-border);
+    padding: 0;
+}
+
+.popover-menu-row {
+    height: 24px;
+    line-height: 24px;
+    padding: 10px;
+    cursor: pointer;
+}
+
+.popover-menu-row .speak-button,
+.popover-menu-row .check,
+.popover-menu-row .add-button,
+.popover-menu-row .three-dot {
+    margin-right: 16px;
+    top: 4px;
+}
+
+.open-button {
+    opacity: 0.5;
 }
 
 .clickable {
@@ -249,6 +283,7 @@ input[type="search"] {
 }
 
 .word-header .add-button,
+.word-header .three-dot,
 .word-header .check {
     cursor: pointer;
     float: right;
@@ -534,6 +569,12 @@ h2.word-header {
     margin-left: 4px;
 }
 
+.example .add-button,
+.example .three-dot {
+    margin-left: 28px;
+    cursor: pointer;
+}
+
 .sentence-freq-tag {
     font-size: 12px;
 }
@@ -778,7 +819,6 @@ h2.word-header {
     height: var(--right-button-height);
     border: 2px solid;
     border-radius: 100px;
-    margin: var(--right-button-margin);
 }
 
 .check::after {
@@ -806,6 +846,7 @@ h2.word-header {
 
 .right-menu-button-container .check {
     border: 2px solid var(--legend-gradient-start);
+    margin: var(--right-button-margin);
 }
 
 .right-menu-button-container .check::after {
@@ -844,6 +885,33 @@ h2.word-header {
     left: 8px
 }
 
+.three-dot,
+.three-dot::after,
+.three-dot::before {
+    box-sizing: border-box;
+    position: relative;
+    display: block;
+    width: 4px;
+    height: 4px;
+    background: currentColor;
+    border-radius: 100%;
+}
+
+.three-dot::after,
+.three-dot::before {
+    content: "";
+    position: absolute;
+    top: 0;
+}
+
+.three-dot::after {
+    left: -6px;
+}
+
+.three-dot::before {
+    right: -6px;
+}
+
 .speak-button {
     box-sizing: border-box;
     position: relative;
@@ -854,8 +922,6 @@ h2.word-header {
     border: 2px solid;
     border-radius: 4px;
     cursor: pointer;
-    margin-top: 8px;
-    margin-left: 16px;
 }
 
 .speak-button::before {
@@ -1213,6 +1279,12 @@ input:checked {
     font-size: var(--target-language-font-size);
 }
 
+.card-question .speak-button,
+.card-answer .speak-button {
+    margin-left: 28px;
+    top: 4px;
+}
+
 .cloze-container {
     margin: 2px;
 }
@@ -1425,6 +1497,9 @@ main.auth-form {
         --graph-expand-button-box-shadow: 0;
         --tag-border: 2px solid #aaaa;
         --checked-input-border: 6px solid #eeee;
+        --popover-background-color: #222;
+        --popover-font-color: #eeee;
+        --menu-popover-border: 3px solid #eee3;
     }
 }
 

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -291,6 +291,10 @@ input[type="search"] {
     margin-top: 10px;
 }
 
+.word-header .three-dot-container {
+    float: right;
+}
+
 #graph {
     height: var(--graph-height);
 }
@@ -569,10 +573,18 @@ h2.word-header {
     margin-left: 4px;
 }
 
-.example .add-button,
-.example .three-dot {
+.example .add-button {
     margin-left: 28px;
     cursor: pointer;
+}
+
+.example .three-dot {
+    margin-left: 46px;
+}
+
+.three-dot-container {
+    cursor: pointer;
+    width: 70px;
 }
 
 .sentence-freq-tag {

--- a/public/index.html
+++ b/public/index.html
@@ -94,7 +94,7 @@
                 <p id="study-call-to-action" class="study-call-to-action">
                     <span id="task-description">What does the text below mean?</span>
                     <span id="task-complete">Studying complete.<br>You can add more
-                        cards when you see the <span class="add-button"></span> button.</span>
+                        cards with the <span class="add-button"></span> button.</span>
                 </p>
                 <p id="card-question-container" class="card-question"></p>
                 <p id="show-answer-button" class="primary-button">Show Answer</p>
@@ -427,6 +427,7 @@
                 list</div>
         </main>
     </div>
+    <div id="menu-popover" popover></div>
     <script type="module" src="/js/bundle.js"></script>
 </body>
 

--- a/public/js/modules/data-layer.js
+++ b/public/js/modules/data-layer.js
@@ -139,6 +139,31 @@ let addClozeCards = function (newCards, text, newKeys, languageKey) {
         }
     }
 };
+
+function addCard(example, text, languageKey) {
+    const card = { ...example, due: Date.now() };
+    let zhJoined = example.zh.join('');
+    if (zhJoined in studyList) {
+        // no-op...user already made this card. Shouldn't happen, but in case
+        // we receive an update from firestore between menu render and button click
+        return;
+    }
+    const newKeys = [zhJoined];
+    studyList[zhJoined] = {
+        en: card.en,
+        due: card.due,
+        zh: card.zh,
+        wrongCount: 0,
+        rightCount: 0,
+        type: cardTypes.RECOGNITION,
+        vocabOrigin: text,
+        language: languageKey || 'zh-CN',
+        added: Date.now()
+    };
+    saveStudyList(newKeys, null, true);
+    callbacks[dataTypes.studyList].forEach(x => x(studyList));
+}
+
 let addCards = function (currentExamples, text, languageKey) {
     let newCards = currentExamples[text].map((x, i) => ({ ...x, due: Date.now() + i }));
     let newKeys = [];
@@ -482,4 +507,4 @@ let writeExploreState = function (words) {
     }));
 }
 
-export { writeExploreState, readExploreState, writeOptionState, readOptionState, registerCallback, saveStudyList, addCards, inStudyList, getStudyList, removeFromStudyList, findOtherCards, updateCard, recordEvent, getStudyResults, initialize, studyResult, dataTypes, cardTypes }
+export { writeExploreState, readExploreState, writeOptionState, readOptionState, registerCallback, saveStudyList, addCard, addCards, inStudyList, getStudyList, removeFromStudyList, findOtherCards, updateCard, recordEvent, getStudyResults, initialize, studyResult, dataTypes, cardTypes }

--- a/public/js/modules/explore.js
+++ b/public/js/modules/explore.js
@@ -309,17 +309,15 @@ function hideMenuPopover() {
     menuPopover.hidePopover();
 }
 
-let popoverMenuShowingTrigger = null;
 function addPopoverMenuButton(word, example, container, text, aList, cardType) {
     const button = document.createElement('span');
     button.classList.add('add-button');
     container.appendChild(button);
     button.addEventListener('click', function () {
         // if already showing, keep showing it but re-render and move
-        if (popoverMenuShowingTrigger == button || button.classList.contains('open-button')) {
+        if (button.classList.contains('open-button')) {
             menuPopover.hidePopover();
             button.classList.remove('open-button');
-            popoverMenuShowingTrigger = null;
             return;
         }
         for (const openButton of document.querySelectorAll('.open-button')) {
@@ -335,7 +333,6 @@ function addPopoverMenuButton(word, example, container, text, aList, cardType) {
         }
         renderMenu(word, aList, text, example, cardType);
         menuPopover.showPopover();
-        popoverMenuShowingTrigger = button;
     });
 }
 
@@ -861,7 +858,6 @@ let initialize = function () {
         if (event.newState === "closed") {
             // needed as clicking the button a second time or clicking outside the menu and button
             // can both close the popover menu
-            popoverMenuShowingTrigger = null;
             for (const button of document.querySelectorAll('.open-button')) {
                 button.classList.remove('open-button')
             }

--- a/public/js/modules/explore.js
+++ b/public/js/modules/explore.js
@@ -267,7 +267,11 @@ function renderMenu(word, aList, text, example, cardType) {
     textToSpeechButton.className = 'speak-button';
     const speakSpan = document.createElement('span');
     speakSpan.innerText = 'Listen';
-    speakRow.addEventListener('click', runTextToSpeech.bind(this, text, aList), false);
+    speakRow.addEventListener('click', function () {
+        runTextToSpeech(text, aList);
+        // hide the popover so as not to cover highlighting while speaking
+        setTimeout(hideMenuPopover, 250);
+    });
     speakRow.appendChild(textToSpeechButton);
     speakRow.appendChild(speakSpan);
 
@@ -288,6 +292,8 @@ function renderMenu(word, aList, text, example, cardType) {
         addSpan.classList.add('check');
         addTextSpan.innerText = 'Flashcard added';
         showNotification();
+        // give the user a brief moment to see the success message, then close.
+        setTimeout(hideMenuPopover, 1000);
     });
     addCardRow.appendChild(addSpan);
     addCardRow.appendChild(addTextSpan);

--- a/public/js/modules/explore.js
+++ b/public/js/modules/explore.js
@@ -1,4 +1,4 @@
-import { writeExploreState, addCards, inStudyList } from "./data-layer.js";
+import { writeExploreState, addCard, inStudyList } from "./data-layer.js";
 import { hanziBox, notFoundElement, walkThrough, examplesList } from "./dom.js";
 import { getActiveGraph, getPartition } from "./options.js";
 import { renderCoverageGraph } from "./coverage-graph"
@@ -13,6 +13,7 @@ let charFreqs = null;
 let maxExamples = 5;
 let currentExamples = {};
 let currentWords = [];
+let menuPopover;
 
 const modes = {
     explore: 'explore',
@@ -102,22 +103,6 @@ let runTextToSpeech = function (text, anchors) {
     }
 };
 
-let addTextToSpeech = function (container, text, aList) {
-    let textToSpeechButton = document.createElement('span');
-    textToSpeechButton.className = 'speak-button';
-    textToSpeechButton.addEventListener('click', runTextToSpeech.bind(this, text, aList), false);
-    container.appendChild(textToSpeechButton);
-};
-let addSaveToListButton = function (container, text) {
-    let saveToListButton = document.createElement('span');
-    saveToListButton.className = (inStudyList(text) ? 'check' : 'add-button');
-    saveToListButton.addEventListener('click', function () {
-        addCards(currentExamples, text);
-        saveToListButton.className = 'check';
-        showNotification();
-    });
-    container.appendChild(saveToListButton);
-};
 let renderPinyinForDefinition = function (pinyin, container) {
     const syllables = pinyin.split(' ');
     for (const syllable of syllables) {
@@ -266,7 +251,91 @@ let findExamples = function (word, sentences, max) {
     });
     return examples;
 };
-let setupExampleElements = function (examples, exampleList, defaultSource) {
+let addTextToSpeech = function (container, text, aList) {
+    let textToSpeechButton = document.createElement('span');
+    textToSpeechButton.className = 'speak-button';
+    textToSpeechButton.addEventListener('click', runTextToSpeech.bind(this, text, aList), false);
+    container.appendChild(textToSpeechButton);
+};
+
+
+function renderMenu(word, aList, text, example, cardType) {
+    menuPopover.innerHTML = '';
+    const speakRow = document.createElement('div');
+    speakRow.classList.add('popover-menu-row');
+    let textToSpeechButton = document.createElement('span');
+    textToSpeechButton.className = 'speak-button';
+    const speakSpan = document.createElement('span');
+    speakSpan.innerText = 'Listen';
+    speakRow.addEventListener('click', runTextToSpeech.bind(this, text, aList), false);
+    speakRow.appendChild(textToSpeechButton);
+    speakRow.appendChild(speakSpan);
+
+    const addCardRow = document.createElement('div');
+    addCardRow.classList.add('popover-menu-row');
+    const addSpan = document.createElement('span');
+    addSpan.classList.add(inStudyList(text) ? 'check' : 'add-button');
+    const addTextSpan = document.createElement('span');
+    addTextSpan.innerText = inStudyList(text) ? 'Flashcard added' : `Add ${cardType} flashcard`;
+    addCardRow.addEventListener('click', function () {
+        if (cardType === cardTypes.sentence) {
+            addCard(example, word, getActiveGraph().locale);
+        } else {
+            const definitionCard = currentExamples[word].find(x => x.type === cardTypes.definition);
+            addCard(definitionCard, word, getActiveGraph().locale);
+        }
+        addSpan.classList.remove('add-button');
+        addSpan.classList.add('check');
+        addTextSpan.innerText = 'Flashcard added';
+        showNotification();
+    });
+    addCardRow.appendChild(addSpan);
+    addCardRow.appendChild(addTextSpan);
+
+    menuPopover.appendChild(speakRow);
+    menuPopover.appendChild(addCardRow);
+}
+
+const cardTypes = {
+    definition: 'definition',
+    sentence: 'sentence'
+};
+
+const NUM_MENU_ROWS = 2;
+// TODO: keep in sync with css....not great. 20 for padding, 24 for height
+const ROW_HEIGHT = 44;
+
+let popoverMenuShowingTrigger = null;
+function addPopoverMenuButton(word, example, container, text, aList, cardType) {
+    const button = document.createElement('span');
+    button.classList.add('add-button');
+    container.appendChild(button);
+    button.addEventListener('click', function () {
+        // if already showing, keep showing it but re-render and move
+        if (popoverMenuShowingTrigger == button) {
+            menuPopover.hidePopover();
+            button.classList.remove('open-button');
+            popoverMenuShowingTrigger = null;
+            return;
+        }
+        for (const openButton of document.querySelectorAll('.open-button')) {
+            openButton.classList.remove('open-button');
+        }
+        button.classList.add('open-button');
+        const buttonDimensions = button.getBoundingClientRect();
+        menuPopover.style.left = `${buttonDimensions.left - 215}px`;
+        if (buttonDimensions.bottom + (NUM_MENU_ROWS * 44) < window.visualViewport.height) {
+            menuPopover.style.top = `${buttonDimensions.top + 22}px`;
+        } else {
+            menuPopover.style.top = `${buttonDimensions.top - (NUM_MENU_ROWS * ROW_HEIGHT) - 6}px`;
+        }
+        renderMenu(word, aList, text, example, cardType);
+        menuPopover.showPopover();
+        popoverMenuShowingTrigger = button;
+    });
+}
+
+let setupExampleElements = function (word, examples, exampleList, defaultSource) {
     for (let i = 0; i < examples.length; i++) {
         let exampleHolder = document.createElement('li');
         exampleHolder.classList.add('example');
@@ -274,7 +343,7 @@ let setupExampleElements = function (examples, exampleList, defaultSource) {
         let exampleText = examples[i].zh.join('');
         let aList = makeSentenceNavigable(exampleText, zhHolder, true);
         zhHolder.className = 'target';
-        addTextToSpeech(zhHolder, exampleText, aList);
+        addPopoverMenuButton(word, examples[i], zhHolder, exampleText, aList, cardTypes.sentence);
         exampleHolder.appendChild(zhHolder);
         if (examples[i].pinyin) {
             let pinyinHolder = document.createElement('p');
@@ -342,7 +411,7 @@ let augmentExamples = function (word, container, maxExamples) {
                 return false;
             }
             let examples = findExamples(word, data, maxExamples || 2);
-            setupExampleElements(examples, container, getActiveGraph().secondarySentenceSource);
+            setupExampleElements(word, examples, container, getActiveGraph().secondarySentenceSource);
             currentExamples[word].push(...examples);
         });
 };
@@ -360,7 +429,9 @@ let augmentDefinitions = function (word, container) {
             // now that we know the tones of the word/character, modify the header to be color-coded, too.
             modifyHeaderTones(definitionList, word);
             // TODO(refactor): should this be moved to setupDefinitions (and same with setupExamples/augmentExamples)?
-            currentExamples[word].push(getCardFromDefinitions(word, definitionList));
+            if (definitionList.length > 0) {
+                currentExamples[word].push(getCardFromDefinitions(word, definitionList));
+            }
         });
 };
 let renderDefinitions = function (word, definitionList, container) {
@@ -426,8 +497,7 @@ let renderWordHeader = function (word, container, active) {
     wordSpan.id = `${word}-header`;
     wordSpan.classList.add('clickable');
     wordHolder.appendChild(wordSpan);
-    addTextToSpeech(wordHolder, word, []);
-    addSaveToListButton(wordHolder, word);
+    addPopoverMenuButton(word, null, wordHolder, word, [], cardTypes.definition);
     if (active) {
         wordHolder.classList.add('active');
     }
@@ -446,7 +516,7 @@ let renderExamples = function (word, examples, maxExamples, container) {
     exampleList.classList.add('examples');
     container.appendChild(exampleList);
     if (examples.length > 0) {
-        setupExampleElements(examples, exampleList, 'tatoeba');
+        setupExampleElements(word, examples, exampleList, 'tatoeba');
     } else if (getActiveGraph().augmentPath) {
         augmentExamples(word, exampleList, maxExamples);
     }
@@ -496,6 +566,13 @@ function switchToTab(id, tabs) {
     for (const [tabId, elements] of Object.entries(tabs)) {
         const separator = elements.tab.querySelector('.separator');
         if (id === tabId) {
+            if (elements.tab.classList.contains('active')) {
+                // tab is already active, so no need to switch to it
+                // the `else` below also needn't be run for the other tabs
+                // but it's also ok if it is, or else we could do a first
+                // loop to get this answer and then the main one.
+                return;
+            }
             elements.tab.classList.add('active');
             separator.classList.add('expand');
             elements.panel.removeAttribute('style');
@@ -691,7 +768,9 @@ let setupExamples = function (words, type, skipState) {
 
         currentExamples[words[i]] = [];
         //TODO: definition list doesn't have the same interface (missing zh field)
-        currentExamples[words[i]].push(getCardFromDefinitions(words[i], definitionList));
+        if (definitionList.length > 0) {
+            currentExamples[words[i]].push(getCardFromDefinitions(words[i], definitionList));
+        }
         //setup current examples for potential future export
         currentExamples[words[i]].push(...examples);
 
@@ -733,8 +812,8 @@ let persistNavigationState = function (words) {
 // TODO: enable adding specific definition cards rather than all at once
 let getCardFromDefinitions = function (text, definitionList) {
     let parsedDefinitions = parseDefinitions(definitionList);
-    //this assumes definitionList non null
-    let result = { zh: [text] };
+    //this assumes definitionList non null and non empty
+    let result = { zh: [text], type: cardTypes.definition };
     let answer = Object.values(parsedDefinitions).map(item => {
         return `${item[0].pinyin}: ${item.map(x => x.en).join(', ')}`;
     }).join('; ');
@@ -771,6 +850,21 @@ let initialize = function () {
         if (currentMode === modes.components) {
             switchToTab('tab-components', currentTabs);
         }
+    });
+    menuPopover = document.getElementById('menu-popover');
+    menuPopover.addEventListener('toggle', function (event) {
+        if (event.newState === "closed") {
+            // needed as clicking the button a second time or clicking outside the menu and button
+            // can both close the popover menu
+            popoverMenuShowingTrigger = null;
+            for (const button of document.querySelectorAll('.open-button')) {
+                button.classList.remove('open-button')
+            }
+        }
+    });
+    window.addEventListener('resize', function () {
+        // resizing the screen throws off positioning of the menu...just hide it
+        menuPopover.hidePopover();
     });
     voice = getVoice();
     fetchStats();

--- a/public/js/modules/explore.js
+++ b/public/js/modules/explore.js
@@ -305,6 +305,10 @@ const NUM_MENU_ROWS = 2;
 // TODO: keep in sync with css....not great. 20 for padding, 24 for height
 const ROW_HEIGHT = 44;
 
+function hideMenuPopover() {
+    menuPopover.hidePopover();
+}
+
 let popoverMenuShowingTrigger = null;
 function addPopoverMenuButton(word, example, container, text, aList, cardType) {
     const button = document.createElement('span');
@@ -853,6 +857,7 @@ let initialize = function () {
     });
     menuPopover = document.getElementById('menu-popover');
     menuPopover.addEventListener('toggle', function (event) {
+        const container = document.getElementById('explore-container');
         if (event.newState === "closed") {
             // needed as clicking the button a second time or clicking outside the menu and button
             // can both close the popover menu
@@ -860,6 +865,9 @@ let initialize = function () {
             for (const button of document.querySelectorAll('.open-button')) {
                 button.classList.remove('open-button')
             }
+            container.removeEventListener('scroll', hideMenuPopover, { passive: true, once: true });
+        } else {
+            container.addEventListener('scroll', hideMenuPopover, { passive: true, once: true });
         }
     });
     window.addEventListener('resize', function () {

--- a/public/js/modules/explore.js
+++ b/public/js/modules/explore.js
@@ -316,7 +316,7 @@ function addPopoverMenuButton(word, example, container, text, aList, cardType) {
     container.appendChild(button);
     button.addEventListener('click', function () {
         // if already showing, keep showing it but re-render and move
-        if (popoverMenuShowingTrigger == button) {
+        if (popoverMenuShowingTrigger == button || button.classList.contains('open-button')) {
             menuPopover.hidePopover();
             button.classList.remove('open-button');
             popoverMenuShowingTrigger = null;


### PR DESCRIPTION
Previously, there was an add button by the word header, which would add all flash cards. This was convenient if you like all the sentences, but if not, it quickly results in cruft, and if you have a bunch due, it's hard to remember which you wanted to delete vs keep.

This also sets us up for adding more buttons.
* Copy to clipboard
* this word in N cards
* generate more sentences via AI API
* explain grammar via AI etc.