### PR TITLE
Allow SM2 ease to grow with correct answers

### DIFF
--- a/public/js/modules/data-layer.js
+++ b/public/js/modules/data-layer.js
@@ -96,7 +96,7 @@ let updateCard = function (result, key) {
         card.streak = card.nextJump ? (1 + (Math.log(card.nextJump) / Math.log(2))) : 0;
     }
     card.lastReviewTimestamp = Date.now();
-    const score = (result === studyResult.CORRECT) ? 4 : 1;
+    const score = (result === studyResult.CORRECT) ? 5 : 1;
     if (result === studyResult.INCORRECT) {
         card.streak = 0;
         card.interval = 0;


### PR DESCRIPTION
Still should use FSRS instead...
But the prior implementation caused ease to only shrink or stay constant.
Now, ease grows when the user says they got the right answer.
Another option would be to add a button for "got it right, but it was hard",
but I prefer yes/no. It's less important that a user memorize each sentence
anyway, it's more about consistent exposure to plenty of Chinese text, with
varied vocabulary.