### PR TITLE
Hide scrollbars on heat map calendar grids

### DIFF
--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -1355,8 +1355,8 @@ input:checked {
 
 .calendar-day {
     background-color: var(--calendar-day-color);
-    width: 17px;
-    height: 17px;
+    width: 19px;
+    height: 19px;
     margin: 3px;
     border-radius: 4px;
 }


### PR DESCRIPTION
The scrollbar isn't useful there and can block clicks/taps.