### PR TITLE
Disallow overscroll to feel more native

### DIFF
--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -95,7 +95,7 @@ body {
     -webkit-tap-highlight-color: transparent;
     /* in general, disallow overscroll gestures from causing refresh */
     /* the idea is to feel more like a native app */
-    overscroll-behavior: none;
+    overscroll-behavior: contain;
 }
 
 body.allow-overscroll {

--- a/public/css/hanzi-graph.css
+++ b/public/css/hanzi-graph.css
@@ -93,6 +93,16 @@ body {
         https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-tap-highlight-color
     */
     -webkit-tap-highlight-color: transparent;
+    /* in general, disallow overscroll gestures from causing refresh */
+    /* the idea is to feel more like a native app */
+    overscroll-behavior: none;
+}
+
+body.allow-overscroll {
+    /* however, the onSnapshot listener in Android Chrome stops updating occasionally for unknown */
+    /* reasons. This is a hack that allows pull-to-refresh when in study mode and not otherwise */
+    /* vs adding a "force sync" button */
+    overscroll-behavior: auto;
 }
 
 a {

--- a/public/js/modules/ui-orchestrator.js
+++ b/public/js/modules/ui-orchestrator.js
@@ -56,7 +56,8 @@ const states = {
         rightState: 'main',
         paneAnimation: 'slide-in',
         activateCallbacks: [],
-        deactivateCallbacks: []
+        deactivateCallbacks: [],
+        bodyClass: 'allow-overscroll'
     },
     faq: {
         leftButtonClass: 'exit-button',
@@ -125,6 +126,11 @@ function switchToState(state) {
         stateConfig.activeContainer.addEventListener('animationend', function () {
             stateConfig.activeContainer.classList.remove(stateConfig.animation);
         }, { once: true });
+    }
+    if(stateConfig.bodyClass) {
+        document.body.className = stateConfig.bodyClass;
+    } else {
+        document.body.removeAttribute('class');
     }
 
     if (stateConfig.activePane) {


### PR DESCRIPTION
Except in study mode, as a hack until the onSnapshot issue is fixed.