### PR TITLE
Add support for gamepad controls on flash cards

### DIFF
--- a/public/js/modules/explore.js
+++ b/public/js/modules/explore.js
@@ -277,6 +277,7 @@ let addTextToSpeech = function (container, text, aList) {
     textToSpeechButton.className = 'speak-button';
     textToSpeechButton.addEventListener('click', runTextToSpeech.bind(this, text, aList), false);
     container.appendChild(textToSpeechButton);
+    return textToSpeechButton;
 };
 
 // TODO: move to its own module, make it less repetitive

--- a/public/js/modules/study-mode.js
+++ b/public/js/modules/study-mode.js
@@ -299,12 +299,8 @@ function isOnlyThisGamepadButtonPushed(buttons, index) {
 }
 
 let gamePadAnimationFrame = null;
-// the specific interface we care about is:
-// press the bottom button of the right cluster (B on switch, A on xbox) to flip the flashcard
-// press the top button of the right cluster (X on switch, Y on xbox) to play audio
-// press the top-left front button (L on switch, LB on xbox) to indicate "wrong"
-// press the top-right front button (R on switch, RB on xbox) to indicate "right"
-// the spec https://w3c.github.io/gamepad/#remapping seems to indicate there's just the one "standard" layout
+// the spec https://w3c.github.io/gamepad/#remapping seems to indicate there's just the one "standard" layout.
+//   image here: https://w3c.github.io/gamepad/standard_gamepad.svg
 // and so:
 // buttons[0] is "flip card"
 // buttons[1] is "flip card" as well, since xbox and switch have different patterns (buttons[0] on xbox is confirm, but switch uses buttons[1])...let either flip
@@ -330,7 +326,7 @@ function runGamePadLoop() {
         return;
     }
     // only allow the first controller to control the flashcard interface
-    const gamepad = gamepads[0];
+    const gamepad = gamepads.find(x => x != null);
     if (!gamepad) {
         return;
     }


### PR DESCRIPTION
This allows you to connect a controller (e.g., switch pro) and use it to perform flash card actions. A/B (since xbox and switch differ) flip the card, Y/X plays the audio, and R/L (RB/LB) mark right or wrong, respectively.

This is quite silly but why not. It's kinda nice to do flashcards this way. This change also adds a keyboard shortcut to play audio.

It's rather unfortunate that the web platform doesn't have button events for gamepads like for keyboards, but I tried to mimic it with a simple state machine and custom events.