### PR TITLE
Enable multi-sentence AI image analysis

### DIFF
--- a/functions/prompts/analyze-image.prompt
+++ b/functions/prompts/analyze-image.prompt
@@ -6,4 +6,5 @@ input:
 output:
   schema: ImageAnalysisSchema
 ---
-Read the Chinese text in this image: {{media url=base64ImageUrl}}, and then explain it, including an English translation and any relevant grammar rules.
+Read the Chinese text in this image: {{media url=base64ImageUrl}}, split it into sentences, and then explain it, including an English translation for each sentence and any relevant grammar rules.
+If the image contains good English translations of the Chinese text, use those verbatim.

--- a/functions/src/schema.ts
+++ b/functions/src/schema.ts
@@ -1,5 +1,15 @@
 import { z } from "genkit";
 
+const sentenceSchema = z.array(
+    z.object({
+        chineseTextWithoutPinyin: z.string(),
+        pinyin: z.string(),
+        englishTranslation: z.string(),
+    }));
+
+// TODO: should the `explanationSchema` and `englishExplanationSchema` also split input into sentences?
+// kinda seems like the user would've split it up themselves if that was the intention, vs an image
+// where it's often tougher to do that.
 export const explanationSchema = z.object({
     plainTextExplanation: z.string(),
     englishTranslation: z.string(),
@@ -26,10 +36,8 @@ export const englishExplanationSchema = z.object({
 // likely be combined. The frontend benefits from a uniform
 // interface.
 export const imageAnalysisSchema = z.object({
+    sentences: sentenceSchema,
     plainTextExplanation: z.string(),
-    chineseTranslationWithoutPinyin: z.string(),
-    englishTranslation: z.string(),
-    pinyin: z.string(),
     grammarHighlights: z.array(
         z.object({
             grammarConceptName: z.string(),
@@ -41,13 +49,6 @@ export const generateChineseSentencesInputSchema = z.object({
     word: z.string(),
     definitions: z.array(z.string()),
 });
-
-const sentenceSchema = z.array(
-    z.object({
-        chineseTextWithoutPinyin: z.string(),
-        pinyin: z.string(),
-        englishTranslation: z.string(),
-    }));
 
 export const chineseSentenceGenerationSchema = z.object({
     sentences: sentenceSchema,

--- a/public/js/modules/explore.js
+++ b/public/js/modules/explore.js
@@ -970,7 +970,7 @@ function renderAiExplanationResponse(words, response, container) {
     exampleHeader.innerText = "Translated";
     // this kinda just works like a normal example here...
     const exampleList = document.createElement('ul');
-    setupExampleElements(null, [{ zh: words, pinyin: data.pinyin, en: data.englishTranslation }], exampleList, 'user');
+    setupExampleElements(null, data.sentences || [{ zh: words, pinyin: data.pinyin, en: data.englishTranslation }], exampleList, 'user');
 
     const explanationContainer = document.createElement('div');
     explanationContainer.classList.add('ai-explanation');

--- a/public/js/modules/file-analysis.js
+++ b/public/js/modules/file-analysis.js
@@ -26,7 +26,7 @@ function handleFile(file) {
             searchControl.style.display = 'none';
             document.dispatchEvent(new CustomEvent('loading-dots'));
             const aiData = await analyzeImage(reader.result);
-            document.dispatchEvent(new CustomEvent('ai-response', { detail: { aiData } }));
+            document.dispatchEvent(new CustomEvent('ai-file-response', { detail: { aiData } }));
         } catch (ex) {
             notFoundElement.removeAttribute('style');
             document.dispatchEvent(new CustomEvent('hide-loading-dots'));

--- a/public/js/modules/search-suggestions-worker.js
+++ b/public/js/modules/search-suggestions-worker.js
@@ -269,7 +269,9 @@ onmessage = async function (e) {
         postMessage({
             result,
             type: e.data.type,
-            word: e.data.payload.word
+            next: e.data.next,
+            word: e.data.payload.word,
+            aiData: e.data.payload.aiData
         });
     }
 }


### PR DESCRIPTION
Previously, we assumed one big block of text per image, but this makes it much easier to make more targeted flashcards. The other AI response schemas remain the same, as it's assumed you can break up the text easily yourself in those cases.

The frontend code handling all this is a total mess. Rewrite needed.