### PR TITLE
Reverse proxy support for custom server base path

### DIFF
--- a/scripts/server_with_rewrites.py
+++ b/scripts/server_with_rewrites.py
@@ -1,16 +1,28 @@
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 import argparse
 
+class MyHTTPServer(HTTPServer):
+    def __init__(self, server_address, RequestHandlerClass,
+                 base_path='',
+                 bind_and_activate=True):
+        HTTPServer.__init__(self, server_address, RequestHandlerClass, bind_and_activate=bind_and_activate)
+        self.base_path = base_path
+
 
 class RequestHandler(SimpleHTTPRequestHandler):
-
     # mimic firebase hosting's rewrite rules
-    def translate_path(self, path):
-        if path.startswith('/simplified') or path.startswith('/traditional') or path.startswith('/cantonese') or path.startswith('/hsk'):
+    def translate_path(self, request_path):
+        base_path = self.server.base_path if isinstance(self.server, MyHTTPServer) else ''
+        slashed_path = request_path.removeprefix(base_path)
+        crit_blank = slashed_path in ('/', '')
+        crit_specials = any([slashed_path.startswith(f"{candidate}") for candidate in (
+            '/simplified', '/traditional', '/cantonese', '/hsk'
+        )])
+        if crit_blank or crit_specials:
             return 'index.html'
-        # prepend . such that the frontend's use of /whatever results in ./whatever
-        # should maybe just strip the first character, tbh
-        return f".{path}"
+        # now turn the slashed path /foo/bar into ./foo/bar on disk
+        path = f".{slashed_path}"
+        return path
 
 
 if __name__ == '__main__':
@@ -20,9 +32,16 @@ if __name__ == '__main__':
         description='Enable URL rewrites without relying on firebase hosting. Intended to be run from the public/ directory.')
     parser.add_argument(
         '--port', help='your choice of port; default 8000', nargs='?', default=8000, type=int)
+    parser.add_argument(
+        '--base-path', help='custom base path, e.g. /app/hanzi; useful for reverse proxy', default='')
     args = parser.parse_args()
     port = int(args.port)
-    myServer = HTTPServer(('0.0.0.0', port), RequestHandler)
+    base_path = args.base_path
+    if base_path:
+        assert base_path[0] == '/', '--base-path must start with /'
+        if base_path[-1] == '/':
+            base_path = base_path[:-1]
+    myServer = MyHTTPServer(('0.0.0.0', port), RequestHandler, base_path=base_path)
     print("HanziGraph started")
     try:
         myServer.serve_forever()


### PR DESCRIPTION
My self hosted apps are typically under a https://mydomain.com/app path.
The web app should have a way of handling requests under a base path which is not necessarily root.

This is my first attempt.

I believe some more code tweaking is needed since not all requests seem to go through the python server's handler.

Inputs and suggestions are highly appreciated as I'd like to be able to host a variant of this app with configurability on reverse proxies.

Thanks!