### PR TITLE
Upgrade to Gemini 3

### DIFF
--- a/.github/workflows/eval-functions.yml
+++ b/.github/workflows/eval-functions.yml
@@ -108,30 +108,35 @@ jobs:
           genkit eval:flow explainText \
             --input datasets/explain-chinese.json \
             --evaluators=custom/chineseTextPresent,custom/validPinyinFormat,custom/outputStructureValid,custom/grammarExplanationQuality \
+            --batchSize 10 \
             --output eval-results/explain-chinese-results.json || { echo "⚠️ explainText evaluation had errors"; EVAL_ERRORS=$((EVAL_ERRORS+1)); }
 
           echo "Running explainEnglish evaluation..."
           genkit eval:flow explainEnglish \
             --input datasets/explain-english.json \
             --evaluators=custom/chineseTextPresent,custom/validPinyinFormat,custom/outputStructureValid,custom/grammarExplanationQuality \
+            --batchSize 10 \
             --output eval-results/explain-english-results.json || { echo "⚠️ explainEnglish evaluation had errors"; EVAL_ERRORS=$((EVAL_ERRORS+1)); }
 
           echo "Running generateChineseSentences evaluation..."
           genkit eval:flow generateChineseSentences \
             --input datasets/generate-chinese-sentences.json \
             --evaluators=custom/chineseTextPresent,custom/validPinyinFormat,custom/outputStructureValid,custom/sentenceGenerationQuality \
+            --batchSize 10 \
             --output eval-results/generate-sentences-results.json || { echo "⚠️ generateChineseSentences evaluation had errors"; EVAL_ERRORS=$((EVAL_ERRORS+1)); }
 
           echo "Running analyzeCollocation evaluation..."
           genkit eval:flow analyzeCollocation \
             --input datasets/analyze-collocation.json \
             --evaluators=custom/chineseTextPresent,custom/englishTranslationPresent,custom/outputStructureValid \
+            --batchSize 10 \
             --output eval-results/collocation-results.json || { echo "⚠️ analyzeCollocation evaluation had errors"; EVAL_ERRORS=$((EVAL_ERRORS+1)); }
 
           echo "Running explainWordInContext evaluation..."
           genkit eval:flow explainWordInContext \
             --input datasets/explain-word-in-context.json \
             --evaluators=custom/chineseTextPresent,custom/englishTranslationPresent,custom/outputStructureValid \
+            --batchSize 10 \
             --output eval-results/word-context-results.json || { echo "⚠️ explainWordInContext evaluation had errors"; EVAL_ERRORS=$((EVAL_ERRORS+1)); }
 
           if [ $EVAL_ERRORS -gt 0 ]; then

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,11 +8,11 @@
       "dependencies": {
         "@genkit-ai/evaluator": "^1.27.0",
         "@genkit-ai/firebase": "^1.0.5",
-        "@genkit-ai/vertexai": "^1.0.5",
+        "@genkit-ai/google-genai": "^1.28.0",
         "express": "^4.21.2",
         "firebase-admin": "^12.6.0",
         "firebase-functions": "^6.0.1",
-        "genkit": "^1.0.5"
+        "genkit": "^1.28.0"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -42,47 +42,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.24.3",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.24.3.tgz",
-      "integrity": "sha512-916wJXO6T6k8R6BAAcLhLPv/pnLGy7YSEBZXZ1XTFbLcTZE8oTy3oDW9WJf9KKZwMvVcePIfoTSvzXHRcGxkQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "web-streams-polyfill": "^3.2.1"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.76",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
-      "integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
-    },
-    "node_modules/@anthropic-ai/vertex-sdk": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.4.3.tgz",
-      "integrity": "sha512-2Uef0C5P2Hx+T88RnUSRA3u4aZqmqnrRSOb2N64ozgKPiSUPTM5JlggAq2b32yWMj5d3MLYa6spJXKMmHXOcoA==",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": ">=0.14 <1",
-        "google-auth-library": "^9.4.2"
       }
     },
     "node_modules/@asteasolutions/zod-to-openapi": {
@@ -628,6 +587,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -1229,12 +1195,12 @@
       }
     },
     "node_modules/@genkit-ai/ai": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/ai/-/ai-1.27.0.tgz",
-      "integrity": "sha512-Vogp21a0pBgL7UsdHj1Jm79PjrQdLNRK5dZT05Xvr3f7GwCNMv0k6Olxp+qrgwLi6DbRsVPi7c+wcldekMlLFQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/ai/-/ai-1.28.0.tgz",
+      "integrity": "sha512-hP2w/ZSRSy3qCk1eIKhsouVzvApNowaq2fpK/rIGRNAp4U6NzaYFRgof5yGGJZ9/ez5ScahhoM0m78e48EdxVg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@genkit-ai/core": "1.27.0",
+        "@genkit-ai/core": "1.28.0",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.11.19",
         "colorette": "^2.0.20",
@@ -1247,9 +1213,9 @@
       }
     },
     "node_modules/@genkit-ai/ai/node_modules/@types/node": {
-      "version": "20.19.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1280,9 +1246,9 @@
       "license": "MIT"
     },
     "node_modules/@genkit-ai/core": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-1.27.0.tgz",
-      "integrity": "sha512-2dcr/yKixcxNj0U9pFpx9qNOTJcRdEjEz76qd5+o6Ac31foRBMb3J9Bvrfr+SaaPI4kiMnFUxN1X+w5yNjryQg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-1.28.0.tgz",
+      "integrity": "sha512-/0/1FErF4BgrI5VOKQS4gQq2gd/KxuSPDKz/I31KEbtzyhP829BMTEBq3hQaxFxUsjNPpvQoxjZp4yYF5KG5fQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -1296,7 +1262,6 @@
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
         "async-mutex": "^0.5.0",
-        "body-parser": "^1.20.3",
         "cors": "^2.8.5",
         "dotprompt": "^1.1.1",
         "express": "^4.21.0",
@@ -1306,6 +1271,7 @@
         "zod-to-json-schema": "^3.22.4"
       },
       "optionalDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
         "@genkit-ai/firebase": "^1.16.1"
       }
     },
@@ -1592,6 +1558,19 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/@genkit-ai/google-genai": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/google-genai/-/google-genai-1.28.0.tgz",
+      "integrity": "sha512-B61BvCGyVsJHKwouTC/oj9HjzG8qVcKJzq7Qajo9xSsuckSwWIWQVQknbSK254k7cl8jxkisp8juH9oY3568ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "jsonpath-plus": "^10.3.0"
+      },
+      "peerDependencies": {
+        "genkit": "^1.28.0"
+      }
+    },
     "node_modules/@genkit-ai/telemetry-server": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@genkit-ai/telemetry-server/-/telemetry-server-1.0.5.tgz",
@@ -1728,98 +1707,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@genkit-ai/vertexai": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/vertexai/-/vertexai-1.0.5.tgz",
-      "integrity": "sha512-ij+eHzevACPy3C4rDcIUQ0/pcEy1cAk+AdJCtLW91NvRceVoyvmiIsPxCiK6NdFvdpnn/MM+sRB831wCzIyWgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.24.3",
-        "@anthropic-ai/vertex-sdk": "^0.4.0",
-        "@google-cloud/aiplatform": "^3.23.0",
-        "@google-cloud/vertexai": "^1.9.3",
-        "@mistralai/mistralai-gcp": "^1.3.5",
-        "google-auth-library": "^9.14.2",
-        "googleapis": "^140.0.1",
-        "node-fetch": "^3.3.2",
-        "openai": "^4.52.7"
-      },
-      "optionalDependencies": {
-        "@google-cloud/bigquery": "^7.8.0",
-        "firebase-admin": ">=12.2"
-      },
-      "peerDependencies": {
-        "genkit": "^1.0.5"
-      }
-    },
-    "node_modules/@genkit-ai/vertexai/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/@google-cloud/aiplatform": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/aiplatform/-/aiplatform-3.34.0.tgz",
-      "integrity": "sha512-Ii1CXJ59g5hcVYNZOx08XBV5nq0JIOSo2I9uC/WYkdXWekc3XSV9emRz8pKOQSULzrTOTnD80N4re49S07xfyQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-gax": "^4.0.3",
-        "protobuf.js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@google-cloud/bigquery": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-7.9.2.tgz",
-      "integrity": "sha512-Yo7oYE6m7bBT28tYDn6dBwbXZxCt+nWREj/0y5aoUq0rFUGwLUDKAXwgt6OQJ2htDzGiQ3s0yltCBjKFtqVCmA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@google-cloud/common": "^5.0.0",
-        "@google-cloud/paginator": "^5.0.2",
-        "@google-cloud/precise-date": "^4.0.0",
-        "@google-cloud/promisify": "^4.0.0",
-        "arrify": "^2.0.1",
-        "big.js": "^6.0.0",
-        "duplexify": "^4.0.0",
-        "extend": "^3.0.2",
-        "is": "^3.3.0",
-        "stream-events": "^1.0.5",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@google-cloud/bigquery/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2342,18 +2229,6 @@
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@google-cloud/vertexai": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-1.9.3.tgz",
-      "integrity": "sha512-35o5tIEMLW3JeFJOaaMNR2e5sq+6rpnhrF97PuAxeOm0GlqVTESKhkGj7a5B5mmJSSSU3hUfIhcQCRRsw4Ipzg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^9.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -3021,15 +2896,28 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
-    "node_modules/@mistralai/mistralai-gcp": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai-gcp/-/mistralai-gcp-1.4.0.tgz",
-      "integrity": "sha512-QYBbR/T1U4qZ88m6l5RpOlhly2mXWsXi0owicSX6zt6pBaMORxRs6ZRLmaYX5BNjGqxQUl+LtsSwpMtXW2uU2A==",
-      "dependencies": {
-        "google-auth-library": "^9.11.0"
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
       },
       "peerDependencies": {
-        "zod": ">= 3"
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5330,31 +5218,6 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@types/pg": {
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
@@ -5831,18 +5694,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -6357,20 +6208,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/big.js": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
-      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bigjs"
-      }
     },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
@@ -8706,34 +8543,6 @@
         "node": ">= 0.12"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -8883,13 +8692,13 @@
       }
     },
     "node_modules/genkit": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.27.0.tgz",
-      "integrity": "sha512-54OAzw9+dlOs2H4bWnktMwKVA1wwY9XmudKBAz2uBdWhep5r0xHy1qNE6tUVnSgn+LGGaR/0xfYRSs8uqNPFVw==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.28.0.tgz",
+      "integrity": "sha512-vrPr17lbkgrigKuRZDTy4zwlcYxAZoumlvUSONXAZsEg0NzpoB3G5Mh+LMW639rVohRtW+wEP8AELyUDFYT/UQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@genkit-ai/ai": "1.27.0",
-        "@genkit-ai/core": "1.27.0",
+        "@genkit-ai/ai": "1.28.0",
+        "@genkit-ai/core": "1.28.0",
         "uuid": "^10.0.0"
       }
     },
@@ -9189,19 +8998,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/googleapis": {
-      "version": "140.0.1",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-140.0.1.tgz",
-      "integrity": "sha512-ZGvBX4mQcFXO9ACnVNg6Aqy3KtBPB5zTuue43YVLxwn8HSv8jB7w+uDKoIPSoWuxGROgnj2kbng6acXncOQRNA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^9.0.0",
-        "googleapis-common": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/googleapis-common": {
@@ -9506,15 +9302,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9700,16 +9487,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/is": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
-      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/is-array-buffer": {
@@ -10999,6 +10776,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -11090,6 +10876,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -11916,51 +11720,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/openai": {
-      "version": "4.85.3",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.85.3.tgz",
-      "integrity": "sha512-KTMXAK6FPd2IvsPtglMt0J1GyVrjMxCYzu/mVbCPabzzquSJoZlYpHtE0p0ScZPyt11XTc757xSO4j39j5g+Xw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.76",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
-      "integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
-    },
     "node_modules/openapi3-ts": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.4.0.tgz",
@@ -12510,24 +12269,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/protobuf.js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/protobuf.js/-/protobuf.js-1.1.2.tgz",
-      "integrity": "sha512-USO7Xus/pzPw549M1TguiyoOrKEhm9VMXv+CkDufcjMC8Rd7EPbxeRQPEjCV8ua1tm0k7z9xHkogcxovZogWdA==",
-      "license": "MIT",
-      "dependencies": {
-        "long": "~1.1.2"
-      }
-    },
-    "node_modules/protobuf.js/node_modules/long": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/long/-/long-1.1.5.tgz",
-      "integrity": "sha512-TU6nAF5SdasnTr28c7e74P4Crbn9o3/zwo1pM22Wvg2i2vlZ4Eelxwu4QT7j21z0sDBlJDEnEZjXTZg2J8WJrg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/protobufjs": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,11 +21,11 @@
   "dependencies": {
     "@genkit-ai/evaluator": "^1.27.0",
     "@genkit-ai/firebase": "^1.0.5",
-    "@genkit-ai/vertexai": "^1.0.5",
+    "@genkit-ai/google-genai": "^1.28.0",
     "express": "^4.21.2",
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^6.0.1",
-    "genkit": "^1.0.5"
+    "genkit": "^1.28.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",

--- a/functions/src/genkit-eval.ts
+++ b/functions/src/genkit-eval.ts
@@ -38,7 +38,7 @@ const ai = genkit({
             projectId: process.env.GCLOUD_PROJECT || 'hanzigraph',
         }),
     ],
-    model: vertexAI.model('gemini-2.5-flash'),
+    model: vertexAI.model('gemini-2.0-flash'),
 });
 
 // Register schemas - MUST be done before loading prompts

--- a/functions/src/genkit-eval.ts
+++ b/functions/src/genkit-eval.ts
@@ -179,7 +179,7 @@ export const grammarExplanationQualityEvaluator = ai.defineEvaluator(
             JSON.stringify(datapoint.output);
 
         const { output: evalResult } = await ai.generate({
-            model: vertexAI.model('gemini-2.5-pro'),
+            model: vertexAI.model('gemini-3-pro-preview'),
             prompt: `You are evaluating a Chinese language learning tool's output quality.
 
 Input (Chinese text to explain): ${input}
@@ -248,7 +248,7 @@ export const sentenceGenerationQualityEvaluator = ai.defineEvaluator(
             JSON.stringify(datapoint.output);
 
         const { output: evalResult } = await ai.generate({
-            model: vertexAI.model('gemini-2.5-pro'),
+            model: vertexAI.model('gemini-3-pro-preview'),
             prompt: `You are evaluating generated Chinese example sentences for a language learning app.
 
 Input (word and definitions): ${input}

--- a/functions/src/genkit-eval.ts
+++ b/functions/src/genkit-eval.ts
@@ -38,7 +38,7 @@ const ai = genkit({
             projectId: process.env.GCLOUD_PROJECT || 'hanzigraph',
         }),
     ],
-    model: vertexAI.model('gemini-3-pro-preview'),
+    model: vertexAI.model('gemini-3-flash-preview'),
 });
 
 // Register schemas - MUST be done before loading prompts

--- a/functions/src/genkit-eval.ts
+++ b/functions/src/genkit-eval.ts
@@ -34,7 +34,7 @@ import {
 const ai = genkit({
     plugins: [
         vertexAI({
-            location: 'us-central1',
+            location: 'global',
             projectId: process.env.GCLOUD_PROJECT || 'hanzigraph',
         }),
     ],

--- a/functions/src/genkit-eval.ts
+++ b/functions/src/genkit-eval.ts
@@ -38,7 +38,7 @@ const ai = genkit({
             projectId: process.env.GCLOUD_PROJECT || 'hanzigraph',
         }),
     ],
-    model: vertexAI.model('gemini-2.0-flash'),
+    model: vertexAI.model('gemini-2.5-flash'),
 });
 
 // Register schemas - MUST be done before loading prompts

--- a/functions/src/genkit-eval.ts
+++ b/functions/src/genkit-eval.ts
@@ -15,7 +15,7 @@
  */
 
 import { genkit, z } from "genkit";
-import { vertexAI, gemini20Flash001 } from '@genkit-ai/vertexai';
+import { vertexAI } from '@genkit-ai/google-genai';
 import { BaseEvalDataPoint } from 'genkit/evaluator';
 import {
     explanationSchema,
@@ -30,6 +30,7 @@ import {
 
 // Initialize Genkit with evaluation support
 // Note: This instance doesn't include Firebase auth for easier local testing
+// Flows use Flash for cost/speed, but LLM-as-judge evaluators use Pro for accuracy
 const ai = genkit({
     plugins: [
         vertexAI({
@@ -37,7 +38,7 @@ const ai = genkit({
             projectId: process.env.GCLOUD_PROJECT || 'hanzigraph',
         }),
     ],
-    model: gemini20Flash001,
+    model: vertexAI.model('gemini-2.5-flash'),
 });
 
 // Register schemas - MUST be done before loading prompts
@@ -178,6 +179,7 @@ export const grammarExplanationQualityEvaluator = ai.defineEvaluator(
             JSON.stringify(datapoint.output);
 
         const { output: evalResult } = await ai.generate({
+            model: vertexAI.model('gemini-2.5-pro'),
             prompt: `You are evaluating a Chinese language learning tool's output quality.
 
 Input (Chinese text to explain): ${input}
@@ -246,6 +248,7 @@ export const sentenceGenerationQualityEvaluator = ai.defineEvaluator(
             JSON.stringify(datapoint.output);
 
         const { output: evalResult } = await ai.generate({
+            model: vertexAI.model('gemini-2.5-pro'),
             prompt: `You are evaluating generated Chinese example sentences for a language learning app.
 
 Input (word and definitions): ${input}

--- a/functions/src/genkit-eval.ts
+++ b/functions/src/genkit-eval.ts
@@ -38,7 +38,7 @@ const ai = genkit({
             projectId: process.env.GCLOUD_PROJECT || 'hanzigraph',
         }),
     ],
-    model: vertexAI.model('gemini-2.5-flash'),
+    model: vertexAI.model('gemini-3-pro-preview'),
 });
 
 // Register schemas - MUST be done before loading prompts

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,6 @@
 import { onCallGenkit, HttpsError } from "firebase-functions/v2/https";
 import { genkit, z } from "genkit";
-import { vertexAI, gemini20Flash001 } from '@genkit-ai/vertexai';
+import { vertexAI } from '@genkit-ai/google-genai';
 import * as admin from 'firebase-admin';
 import { isUserAuthorized } from "./auth";
 import {
@@ -26,7 +26,7 @@ const ai = genkit({
     plugins: [
         vertexAI({ location: 'us-central1' }),
     ],
-    model: gemini20Flash001,
+    model: vertexAI.model('gemini-2.5-flash'),
 });
 
 const ChineseExplanationSchema = ai.defineSchema('ChineseExplanationSchema', explanationSchema);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -24,9 +24,9 @@ let firebaseApp: admin.app.App;
 // and choose the Gemini (Vertex AI) tab.
 const ai = genkit({
     plugins: [
-        vertexAI({ location: 'us-central1' }),
+        vertexAI({ location: 'global' }),
     ],
-    model: vertexAI.model('gemini-2.5-flash'),
+    model: vertexAI.model('gemini-3-flash-preview'),
 });
 
 const ChineseExplanationSchema = ai.defineSchema('ChineseExplanationSchema', explanationSchema);


### PR DESCRIPTION
Testing out different models, starting with a minimal upgrade to 2.5 flash.
Ideally we'll use Gemini 3, but let's see the delta in eval scores. 2.0 is being
retired, and 2.5 is still cheaper. Will try out pro vs flash, 2.5 vs 3, pending
VertexAI availability of these models.