### PR TITLE
HTTP server to detect resource change

### DIFF
--- a/scripts/server_with_rewrites.py
+++ b/scripts/server_with_rewrites.py
@@ -3,6 +3,12 @@ import argparse
 
 
 class RequestHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        # Without this, browsers apply heuristic caching based on Last-Modified and may serve stale data files.
+        # no-cache forces revalidation on every request; the server still returns 304 when unchanged,
+        #   so the cost is just a round-trip header check.
+        self.send_header('Cache-Control', 'no-cache')
+        super().end_headers()
 
     # mimic firebase hosting's rewrite rules
     def translate_path(self, path):


### PR DESCRIPTION
The current implementation allows the browser to cache and serve resources like wordlists from its cache indefinitely, even if the server side resource already changed / got an upgrade.

This fix adds a no-cache header for resource refresh.

It is also gentle on the server since it reports a 304 when the resource is unchanged.

Tested on a locally deployed server, it worked fine.