### PR TITLE
Don't force graph open on word tap

### DIFF
--- a/public/js/modules/explore.js
+++ b/public/js/modules/explore.js
@@ -1422,7 +1422,6 @@ let makeSentenceNavigable = function (text, container, optionsOrNoExampleChange)
                     wordSpan.classList.add('word-clicked');
 
                     // Update graph with the word
-                    switchDiagramView(diagramKeys.main);
                     document.dispatchEvent(new CustomEvent('graph-update', { detail: word }));
 
                     // Show inline definition if container is provided


### PR DESCRIPTION
If the user minimized the graph, keep it that way until they reopen.